### PR TITLE
Fix context_data issue in 64.EC JSON

### DIFF
--- a/src/database/initial_data_load/64EC.json
+++ b/src/database/initial_data_load/64EC.json
@@ -425,7 +425,7 @@
     "type": "datagridwithtotals",
     "rowTotal": true,
     "columnTotal": true,
-    "contextData": {
+    "context_data": {
       "show_if_quarter_in": "4"
     },
     "label": "What is the unduplicated number of children &&&VARIABLE&&& ever enrolled during the year?",
@@ -475,7 +475,7 @@
     "type": "datagridwithtotals",
     "rowTotal": true,
     "columnTotal": true,
-    "contextData": {
+    "context_data": {
       "show_if_quarter_in": "4"
     },
     "label": "What is the unduplicated number of new enrollees &&&VARIABLE&&& during the year?",
@@ -525,7 +525,7 @@
     "type": "datagridwithtotals",
     "rowTotal": true,
     "columnTotal": true,
-    "contextData": {
+    "context_data": {
       "show_if_quarter_in": "4"
     },
     "label": "What is the unduplicated number of disenrollees &&&VARIABLE&&& during the year?",


### PR DESCRIPTION
## Purpose

To fix the JSON for the form 64.EC

#### Linked Issues to Close

No issues to link to because it is a quick fix

## Approach

This updates the json from the incorrect spelling (contextData) to the correct spelling (context_data). Now the conditional logic is working properly for this form.

## Learning

N/A

## Assorted Notes/Considerations

N/A

#### Pull Request Creator Checklist

- [ ] This PR has an associated GitHub issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] update the architecture diagram if applicable
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [ ] Someone has been assigned this PR.
- [ ] At least one person has been marked as reviewer on this PR.
- [ ] This PR has been assigned to a Project (right hand side, near Assignees etc.)

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated GitHub issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
