### PR TITLE
Add test for unauthenticated routes

### DIFF
--- a/services/ui-src/src/components/UnauthenticatedRoute/UnauthenticatedRoute.test.js
+++ b/services/ui-src/src/components/UnauthenticatedRoute/UnauthenticatedRoute.test.js
@@ -1,0 +1,33 @@
+import React from "react";
+import { mount } from "enzyme";
+import UnauthenticatedRoute from "./UnauthenticatedRoute";
+import * as AppContext from "../../libs/contextLib";
+import { BrowserRouter, Route } from "react-router-dom";
+
+// Mock for useLocation
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useLocation: () => ({
+    pathname: "localhost:3000/"
+  })
+}));
+
+describe("UnauthenticatedRoute tests", () => {
+  test("Check that a route is available", () => {
+    // Set Context values
+    const contextValues = { isAuthenticated: false };
+
+    // Mock useAppContext with new values
+    jest
+      .spyOn(AppContext, "useAppContext")
+      .mockImplementation(() => contextValues);
+
+    const wrapper = mount(
+      <BrowserRouter>
+        <UnauthenticatedRoute />
+      </BrowserRouter>
+    );
+
+    expect(wrapper.containsMatchingElement(<Route />)).toEqual(true);
+  });
+});


### PR DESCRIPTION
## Purpose

Create Jest Unit Test for UnauthenticatedRoute.js

#### Linked Issues to Close

N/A

## Approach

Provides Unit Tests that run against UnauthenticatedRoute.js to check:

- Check that a route is visible on render

## Learning

Mocking useContext (useAppContext)
https://nancyhuynh-til.netlify.app/jest-mocking-useContext/

## Assorted Notes/Considerations

This is a very simple component as such the only test is to ensure that <UnauthenticatedRoute> calls a <Route>

#### Pull Request Creator Checklist

- [ ] This PR has an associated GitHub issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] update the architecture diagram if applicable
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [ ] Someone has been assigned this PR.
- [ ] At least one person has been marked as reviewer on this PR.
- [ ] This PR has been assigned to a Project (right hand side, near Assignees etc.)

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated GitHub issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
