### PR TITLE
9832 - Disable FPL for BO/Admin users

### DIFF
--- a/services/ui-src/src/components/FormHeader/FormHeader.js
+++ b/services/ui-src/src/components/FormHeader/FormHeader.js
@@ -9,6 +9,7 @@ import {
   updateFPL,
   saveForm
 } from "../../store/reducers/singleForm/singleForm";
+import { getUserInfo } from "../../utility-functions/userFunctions";
 
 const FormHeader = ({
   quarter,
@@ -34,6 +35,18 @@ const FormHeader = ({
     return fplRange.substring(fplRange.length - 3);
   };
 
+  const determineUserRole = async () => {
+    const currentUser = await getUserInfo();
+
+    if (
+      currentUser.Items &&
+      (currentUser.Items[0].role === "admin" ||
+        currentUser.Items[0].role === "business")
+    ) {
+      setDisabled(true);
+    }
+  };
+
   useEffect(() => {
     // List of forms that do NOT show fpl
     if (status_id === 4) {
@@ -56,6 +69,7 @@ const FormHeader = ({
         setShowFPL(true);
       }
     }
+    determineUserRole().then();
     fetchData();
   }, [quarter, form, state, year, status_id]);
 
@@ -139,6 +153,7 @@ const FormHeader = ({
                 type="button"
                 className="max-fpl-btn"
                 onClick={updateMaxFPL}
+                disabled={disabled}
               >
                 Apply FPL Changes
               </Button>


### PR DESCRIPTION
## Purpose

FPL max input should not be available for BO and Admin roles. This PR disables the FPL inputs when the current user is has a role of business or admin

#### Linked Issues to Close

close: [#9832](https://qmacbis.atlassian.net/browse/OY2-9832)

## Approach

Checks user role in the FormHeader component. If the user has an admin or business role the two FPL fields (number input and button) are disabled.

## Pull Request Creator Checklist

#### Documentation

- [x] This PR has an associated JIRA issue or issues
- [x] The associated issue(s) are linked above
- [x] This PR and linked issue(s) are adequately documented
- [ ] The architecture diagram has been updated
- [x] The architecture diagram does not require updates as a result of this PR
- [x] This PR and linked issues(s) are a complete description of the change set; an individual or team should be able to understand the issue(s) and changes by reading through this PR and its links, with no further interaction

#### Implementation

- [ ] This PR meets all acceptance criteria for the linked issue(s)
- [ ] This PR has been functionally tested to ensure the changes included do not impact other functionality within the application

#### Automated Testing

- [ ] This PR includes automated testing (new tests have been created and/or existing tests modified to account for changes made)
- [ ] This PR does not require any new automated tests or changes to existing automated testing
- [ ] The automated testing passes for all components touched by this PR

#### Peer Review & Merging

- [ ] At least one person has been marked as reviewer on this PR
- [ ] A Tech Lead or Sr. Developer responsible for merging has been assigned this PR

## Pull Request Reviewer/Assignee Checklist

#### Documentation

- [ ] This PR has an associated JIRA issue or issues
- [ ] The associated issue(s) are linked above
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the change set; an individual or team should be able to understand the issue(s) and changes by reading through this PR and its links, with no further interaction

#### Implementation

- [ ] This PR meets all acceptance criteria for the linked issue(s)
- [ ] This PR has been functionally tested

#### Automated Testing

- [ ] This PR includes new/updated automated testing
- [ ] This PR does not require new/updated automated testing
- [ ] The automated testing passes for all components touched by this PR
