### PR TITLE
bumping up the timeout and memory

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -125,7 +125,7 @@ provider:
     StatusTableArn: ${env:STATUS_TABLE_ARN, cf:database-${self:custom.stage}.StatusTableArn}
     AuthUserTableName: ${env:AUTH_USER_TABLE_NAME, cf:database-${self:custom.stage}.AuthUserTableName}
     AuthUserTableArn: ${env:AUTH_USER_TABLE_ARN, cf:database-${self:custom.stage}.AuthUserTableArn}
-    SteamVersion:  ".v0"
+    SteamVersion: ".v0"
 
 functions:
   loadData:
@@ -140,6 +140,8 @@ functions:
   ForceKafkaSync:
     handler: handlers/kafka/get/forceKafkaSync.main
     role: LambdaApiRole
+    timeout: 900
+    memorySize: 3072
   postKafkaData:
     handler: handlers/kafka/post/postKafkaData.handler
     events:


### PR DESCRIPTION
## Purpose

ForceKafkaSync lambda did not force all the records to trigger Kafka stream because the lambda timed out sooner.

## Approach

Bumped up the timeout duration and the lambda memory.

## Pull Request Creator Checklist

#### Documentation

- [ ] This PR has an associated JIRA issue or issues
- [ ] The associated issue(s) are linked above
- [ ] This PR and linked issue(s) are adequately documented
- [ ] The architecture diagram has been updated
- [ ] The architecture diagram does not require updates as a result of this PR
- [ ] This PR and linked issues(s) are a complete description of the change set; an individual or team should be able to understand the issue(s) and changes by reading through this PR and its links, with no further interaction

#### Implementation

- [ ] This PR meets all acceptance criteria for the linked issue(s)
- [ ] This PR has been functionally tested to ensure the changes included do not impact other functionality within the application

#### Automated Testing

- [ ] This PR includes automated testing (new tests have been created and/or existing tests modified to account for changes made)
- [ ] This PR does not require any new automated tests or changes to existing automated testing
- [ ] The automated testing passes for all components touched by this PR

#### Peer Review & Merging

- [ ] At least one person has been marked as reviewer on this PR
- [ ] A Tech Lead or Sr. Developer responsible for merging has been assigned this PR

## Pull Request Reviewer/Assignee Checklist

#### Documentation

- [ ] This PR has an associated JIRA issue or issues
- [ ] The associated issue(s) are linked above
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the change set; an individual or team should be able to understand the issue(s) and changes by reading through this PR and its links, with no further interaction

#### Implementation

- [ ] This PR meets all acceptance criteria for the linked issue(s)
- [ ] This PR has been functionally tested

#### Automated Testing

- [ ] This PR includes new/updated automated testing
- [ ] This PR does not require new/updated automated testing
- [ ] The automated testing passes for all components touched by this PR
