### PR TITLE
Moved record insertion till after the enrollment counts are added

### DIFF
--- a/services/app-api/handlers/state-forms/post/updateStateForms.js
+++ b/services/app-api/handlers/state-forms/post/updateStateForms.js
@@ -25,13 +25,11 @@ export const main = handler(async (event, context) => {
   };
 
   const result = await dynamoDb.scan(params);
-
   if (result.Count === 0) {
     return [];
   }
 
   const record = result.Items[0];
-  const putItem = { ...record, lastSynced: new Date().toISOString() };
   if (record.form === "21E") {
     record.enrollmentCounts = {
       type: "separate",
@@ -46,6 +44,7 @@ export const main = handler(async (event, context) => {
       count: data.totalEnrollment,
     };
   }
+  const putItem = { ...record, lastSynced: new Date().toISOString() };
 
   const paramsPut = {
     TableName:


### PR DESCRIPTION
This will fix a bug where enrollment counts weren't being saved to DynamoDB
