### PR TITLE
added missing dependecy that sechub requires

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "nightwatch": "^1.5.1",
     "prettier": "2.2.1",
     "serverless": "=2.4.0",
+    "serverless-online": "CMSgov/serverless-online",
     "serverless-s3-bucket-helper": "https://github.com/cmsgov/serverless-s3-bucket-helper",
     "typescript": "^4.0.5",
     "yargs": "^16.1.1"


### PR DESCRIPTION
## Purpose
Added a missing package that the security hub requires, added to QMR but forgot here in SEDS in the last PR.

Related to: 
https://qmacbis.atlassian.net/jira/software/c/projects/OY2/boards/208?modal=detail&selectedIssue=OY2-13088