### PR TITLE
MDCT-1831 Recursive form scan to show all forms

### DIFF
--- a/services/app-api/handlers/forms/post/obtainAvailableForms.js
+++ b/services/app-api/handlers/forms/post/obtainAvailableForms.js
@@ -30,5 +30,5 @@ export const main = handler(async (event, context) => {
     throw new Error("No state form list found for this state");
   }
   // Return the matching list of items in response body
-  return result.Items;
+  return result;
 });


### PR DESCRIPTION
## Purpose

[MDCT-1831](https://qmacbis.atlassian.net/browse/MDCT-1831) Forms for Q3 were not showing. Our judgement is the scan exceeded 1MB (table size is 1-2MB) and it wasn't retrieving the Q3 forms. With this change it should scan the entire table and find all forms, resolving the issue. We're using a [recursive scan that was already present in the app](https://github.com/CMSgov/cms-mdct-seds/blob/master/services/app-api/handlers/shared/sharedFunctions.js#L464-L482).

_Note: This scan operation is very expensive on DBs and it would be best to rearchitect the DB so that we can query rather than scan. The value of this fix depends on the lifespan of SEDS and its integrations with other systems_
