### PR TITLE
[MDCT-2395] Data Recovery Script

### DIFF
--- a/scripts/pitr_recovery.py
+++ b/scripts/pitr_recovery.py
@@ -10,9 +10,9 @@ import time
 #    * run the script (`python3 pitr_recovery.py`)
 RUN_LOCAL = True                        # Target localhost:8000
 STAGE = "master"                        # Prefix for the environment
-TABLE_MAP = [("-state-forms-recovery", "-state-forms"),
-             ("-form-answers-recovery", "-form-answers")]  # (source, destination), aka (backup, original)
-COMMIT_CHANGES = True
+TABLE_MAP = [("-state-forms-recovered", "-state-forms"),
+             ("-form-answers-recovered", "-form-answers")]  # (source, destination), aka (backup, original)
+COMMIT_CHANGES = False
 
 
 def main():
@@ -32,7 +32,7 @@ def main():
 
 def run_transfer(tables, stage, dynamodb):
     (source_table, destination_table) = tables
-    print("Copying ", source_table, "to", destination_table)
+    print("Copying ", stage, source_table, "to", destination_table)
     source = dynamodb.Table(stage + source_table)
     destination = dynamodb.Table(stage + destination_table)
 
@@ -50,7 +50,8 @@ def run_transfer(tables, stage, dynamodb):
         updates.extend(response['Items'])
 
         # Log details
-        print("  -- Accumulated Count:", len(response['Items']))
+        print("  -- Retrieved Count:", len(response['Items']))
+    print(" > Total Count:", len(updates))
 
     # Execute Changes
     if COMMIT_CHANGES:

--- a/scripts/pitr_recovery.py
+++ b/scripts/pitr_recovery.py
@@ -1,0 +1,72 @@
+import boto3
+import time
+
+# This script was created to load data from a PITR-created table after data loss on 3/23/23-3/24/23.
+
+# Running this script:
+#    * Set the aws environment config file with the temporary values in [default] within ~/.aws/config
+#    * `pip install boto3` or `python3 -m pip install boto3`
+#    * Set RUN_LOCAL, RUN_UPDATE, and STAGE appropriately
+#    * run the script (`python3 pitr_recovery.py`)
+RUN_LOCAL = True                        # Target localhost:8000
+STAGE = "master"                        # Prefix for the environment
+TABLE_MAP = [("-state-forms-recovery", "-state-forms"),
+             ("-form-answers-recovery", "-form-answers")]  # (source, destination), aka (backup, original)
+COMMIT_CHANGES = True
+
+
+def main():
+    # Config db connection
+    dynamodb = None
+    stage = STAGE
+    if RUN_LOCAL:
+        dynamodb = boto3.resource(
+            'dynamodb', endpoint_url='http://localhost:8000')
+        stage = "local"
+    else:
+        dynamodb = boto3.resource('dynamodb')
+
+    for tables in TABLE_MAP:
+        run_transfer(tables, stage, dynamodb)
+
+
+def run_transfer(tables, stage, dynamodb):
+    (source_table, destination_table) = tables
+    print("Copying ", source_table, "to", destination_table)
+    source = dynamodb.Table(stage + source_table)
+    destination = dynamodb.Table(stage + destination_table)
+
+    # Perform scan and execute a new batch for each 'LastEvaluatedKey'
+    response = source.scan()
+    updates = response['Items']
+    total_scans = 1
+    while 'LastEvaluatedKey' in response:
+        total_scans += 1
+        print("Batch", total_scans)
+        print("  -- LastEvaluatedKey:", response['LastEvaluatedKey'])
+
+        # BATCH
+        response = source.scan(ExclusiveStartKey=response['LastEvaluatedKey'])
+        updates.extend(response['Items'])
+
+        # Log details
+        print("  -- Accumulated Count:", len(response['Items']))
+
+    # Execute Changes
+    if COMMIT_CHANGES:
+        update(destination, updates)
+
+
+def update(table, changed):
+    print("Preparing Batch")
+    with table.batch_writer() as writer:
+        for item in changed:
+            writer.put_item(Item=item)
+    print("Batch executed")
+
+
+#### RUN #####
+if __name__ == "__main__":
+    start_time = time.time()
+    main()
+    print("--- %s seconds ---" % (time.time() - start_time))

--- a/scripts/pitr_recovery.py
+++ b/scripts/pitr_recovery.py
@@ -8,10 +8,13 @@ import time
 #    * `pip install boto3` or `python3 -m pip install boto3`
 #    * Set RUN_LOCAL, RUN_UPDATE, and STAGE appropriately
 #    * run the script (`python3 pitr_recovery.py`)
-RUN_LOCAL = True                        # Target localhost:8000
-STAGE = "master"                        # Prefix for the environment
+# Target localhost:8000, won't go up to AWS if True
+RUN_LOCAL = True
+# Prefix for the environment (master/val/production)
+STAGE = "master"
 TABLE_MAP = [("-state-forms-recovered", "-state-forms"),
              ("-form-answers-recovered", "-form-answers")]  # (source, destination), aka (backup, original)
+# If True, will execute the changes in the database, rather than just logging them.
 COMMIT_CHANGES = False
 
 


### PR DESCRIPTION
### Description
Quick python script in the same manner as the other saved SEDS data correction scripts, but way less complicated.
Just takes a list of source and destination tables, and copies the entries from one into the other with a batch request.

Instructions for running are included in the script comments


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2395

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
This has been run in dev already against the recovery tables, but feel free to follow the script instructions and set up the aws credentials file before running.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
