### PR TITLE
Force scan to consider last evaluated, and remove dangerous alternative

### DIFF
--- a/services/app-api/handlers/forms/post/obtainAvailableForms.js
+++ b/services/app-api/handlers/forms/post/obtainAvailableForms.js
@@ -1,5 +1,5 @@
+import dynamodbLib from "../../../libs/dynamodb-lib";
 import handler from "../../../libs/handler-lib";
-import { recursiveScan } from "../../shared/sharedFunctions";
 
 /**
  * Returns list of all forms based on state
@@ -25,10 +25,10 @@ export const main = handler(async (event, context) => {
     FilterExpression: "state_id = :stateId",
     ConsistentRead: true,
   };
-  const result = await recursiveScan(params);
+  const result = await dynamodbLib.scan(params);
   if (result.Count === 0) {
     throw new Error("No state form list found for this state");
   }
   // Return the matching list of items in response body
-  return result;
+  return result.Items;
 });

--- a/services/app-api/handlers/shared/sharedFunctions.js
+++ b/services/app-api/handlers/shared/sharedFunctions.js
@@ -39,7 +39,7 @@ export async function getUncertifiedStates(year, quarter) {
       ":quarter": quarter,
     },
     FilterExpression:
-    "#Unceritifiedstatus = :status AND #theYear = :year AND #theQuarter = :quarter",
+      "#Unceritifiedstatus = :status AND #theYear = :year AND #theQuarter = :quarter",
   };
 
   // data returned from the database which contains the database Items
@@ -459,24 +459,4 @@ export const getQuarter = (d) => {
   d = d || new Date();
   const m = Math.floor(d.getMonth() / 3) + 2;
   return m > 4 ? m - 4 : m;
-};
-
-// Scan is limited and sometimes needs to be run recursively to get all results
-// Return and array of individual items
-const recursiveScanItems = [];
-export const recursiveScan = async (params) => {
-  // Get initial scan (up to 1MB)
-  const result = await dynamoDb.scan(params);
-
-  // Add current results to return array
-  recursiveScanItems.push(...result.Items);
-
-  // If LastEvaluatedKey has a value, recursively call the function with
-  // the ExclusiveStartKey set to the last record that was read
-  if (result.LastEvaluatedKey !== undefined) {
-    params.ExclusiveStartKey = result.LastEvaluatedKey;
-    return await recursiveScan(params);
-  }
-
-  return recursiveScanItems;
 };

--- a/services/app-api/libs/dynamodb-lib.js
+++ b/services/app-api/libs/dynamodb-lib.js
@@ -37,7 +37,6 @@ export default {
     }
     return { Items: items, Count: items.length };
   },
-  // scan: (params) => client.scan(params).promise(),
   batchWrite: (params) => client.batchWrite(params).promise(),
   listTables: (params) => database.listTables(params).promise(),
   increment: (params) =>

--- a/services/app-api/libs/dynamodb-lib.js
+++ b/services/app-api/libs/dynamodb-lib.js
@@ -26,7 +26,18 @@ export default {
   query: (params) => client.query(params).promise(),
   update: (params) => client.update(params).promise(),
   delete: (params) => client.delete(params).promise(),
-  scan: (params) => client.scan(params).promise(),
+  scan: async (params) => {
+    const items = [];
+    let complete = false;
+    while (!complete) {
+      const result = await client.scan(params).promise();
+      items.push(...result.Items);
+      params.ExclusiveStartKey = result.LastEvaluatedKey;
+      complete = result.LastEvaluatedKey === undefined;
+    }
+    return { Items: items, Count: items.length };
+  },
+  // scan: (params) => client.scan(params).promise(),
   batchWrite: (params) => client.batchWrite(params).promise(),
   listTables: (params) => database.listTables(params).promise(),
   increment: (params) =>


### PR DESCRIPTION
### Description
Update the scan to consider last evaluated.
Removed a dangerous recursive one that tracked with a global list of items.

I'm on the fence as to whether or not the recursive search should be opt-in or just for all, but I think this bug proves that not having default for all can get devs into some risky spots. Future improvement might be to make the scan optionally opt-out of recursive search, but I have no use case for it at the moment.

You should see this when you try to create existing data now:
![image](https://user-images.githubusercontent.com/6362494/231524290-0fc074d9-75c8-4f11-8b59-ce7eb621d710.png)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2400

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Pull it down, and interact with the app. Nothing should break. Generate a lot of forms (2.5MB). You shouldn't be able to overwrite existing data.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
