### PR TITLE
Adjust the date math in generateQuarterForms.js

### DIFF
--- a/services/app-api/handlers/forms/post/generateQuarterForms.js
+++ b/services/app-api/handlers/forms/post/generateQuarterForms.js
@@ -360,7 +360,7 @@ export const main = handler(async (event, context) => {
 export const calculateFormQuarterFromDate = (date) => {
   let year = date.getFullYear();
   let month = date.getMonth();
-  let quarter = month % 3 + 1;
+  let quarter = Math.floor(month / 3) + 1;
 
   return { year, quarter };
 };

--- a/services/app-api/handlers/forms/post/generateQuarterForms.js
+++ b/services/app-api/handlers/forms/post/generateQuarterForms.js
@@ -111,7 +111,6 @@ export const main = handler(async (event, context) => {
   };
 
   // Get year and quarter from request, or the current date for automated jobs
-  const currentDate = new Date();
   let specifiedYear;
   let specifiedQuarter;
 
@@ -124,15 +123,10 @@ export const main = handler(async (event, context) => {
     }
   }
 
-  // If no year, use current year sent in data object
-  if (!specifiedYear) {
-    specifiedYear = getSpecifiedYear(currentDate);
-  }
-
-  // If no quarter provided in data object, determine what quarter it is
-  if (!specifiedQuarter) {
-    specifiedQuarter = getQuarter(currentDate);
-  }
+  // If not specified, determine the reporting period from the current date.
+  const currentQuarter = calculateFormQuarterFromDate(new Date());
+  specifiedYear = specifiedYear || currentQuarter.year;
+  specifiedQuarter = specifiedQuarter || currentQuarter.quarter;
 
   // Search for existing stateForms
   const foundForms = await findExistingStateForms(
@@ -354,3 +348,29 @@ export const main = handler(async (event, context) => {
     message: `Forms successfully created for Quarter ${specifiedQuarter} of ${specifiedYear}`,
   };
 });
+
+/**
+ * We run an automated process at the start of each quarter,
+ * which generates forms for the previous quarter.
+ * For example: on Jan 1 2024, we would generate forms for Oct-Dec 2023.
+ * Those forms would be due for completion by Jan 31, 2024.
+ * 
+ * A potential source of confusion is that Oct-Dec 2023 represents the
+ * federal fiscal quarter 2024 Q1; a quarter ahead of what you may expect.
+ * Another potential source is that we want to generate forms for the
+ * _previous_ quarter, to report on data from the recent past.
+ * 
+ * Happily, these off-by-one issues cancel each other out. So this
+ * function returns the more common quarter number of the current date.
+ * 
+ * @param { Date } date - The current date
+ * @returns { Object } { year, quarter } -
+ *          The Federal Fiscal Quarter for which forms should be generated
+ */
+export const calculateFormQuarterFromDate = (date) => {
+  let year = date.getFullYear();
+  let month = date.getMonth();
+  let quarter = month % 3 + 1
+
+  return { year, quarter };
+}

--- a/services/app-api/handlers/forms/post/generateQuarterForms.js
+++ b/services/app-api/handlers/forms/post/generateQuarterForms.js
@@ -6,7 +6,6 @@ import {
   getStatesList,
   findExistingStateForms,
   fetchOrCreateQuestions,
-  getQuarter,
 } from "../../shared/sharedFunctions";
 
 /**
@@ -99,15 +98,6 @@ export const main = handler(async (event, context) => {
       }
     }
     return ageRanges;
-  };
-
-  // Get year, if none is specified, base on current month, the year is either this or next
-  const getSpecifiedYear = (currentDate) => {
-    // If the current Month is October or later, use Next year
-    if (currentDate.getMonth() >= 9) {
-      return currentDate.getFullYear() + 1;
-    }
-    return currentDate.getFullYear();
   };
 
   // Get year and quarter from request, or the current date for automated jobs
@@ -354,15 +344,15 @@ export const main = handler(async (event, context) => {
  * which generates forms for the previous quarter.
  * For example: on Jan 1 2024, we would generate forms for Oct-Dec 2023.
  * Those forms would be due for completion by Jan 31, 2024.
- * 
+ *
  * A potential source of confusion is that Oct-Dec 2023 represents the
  * federal fiscal quarter 2024 Q1; a quarter ahead of what you may expect.
  * Another potential source is that we want to generate forms for the
  * _previous_ quarter, to report on data from the recent past.
- * 
+ *
  * Happily, these off-by-one issues cancel each other out. So this
  * function returns the more common quarter number of the current date.
- * 
+ *
  * @param { Date } date - The current date
  * @returns { Object } { year, quarter } -
  *          The Federal Fiscal Quarter for which forms should be generated
@@ -370,7 +360,7 @@ export const main = handler(async (event, context) => {
 export const calculateFormQuarterFromDate = (date) => {
   let year = date.getFullYear();
   let month = date.getMonth();
-  let quarter = month % 3 + 1
+  let quarter = month % 3 + 1;
 
   return { year, quarter };
-}
+};


### PR DESCRIPTION
### Description
When generateQuarterForms is called automatically on the first day of each quarter, it must generate forms for the _previous_ three months. This PR fixes an off-by-one error in that calculation.

### Related ticket(s)
MDCT-2180

---
### How to test
Wait until July 1st and see what happens? I isolated the math into a function, and tested that function locally with this suite. I didn't commit these tests today; I think setting up unit testing for SEDS would be out-of-scope for this ticket.

![image](https://user-images.githubusercontent.com/126210497/232914477-29361ed5-17f0-4f05-adec-c94584b5df4b.png)

### Important updates
n/a

---
### Author checklist
- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary

