### PR TITLE
[MDCT-2742] [MDCT-2743] Missing Answers (64.ECI & 2019/2020 data)

### DIFF
--- a/scripts/form_answer_scan.py
+++ b/scripts/form_answer_scan.py
@@ -1,0 +1,98 @@
+import boto3
+from boto3.dynamodb.conditions import Key, Attr
+import time
+
+# This script was created to load data from a PITR-created table after data loss on 3/23/23-3/24/23.
+
+# Running this script:
+#    * Set the aws environment config file with the temporary values in [default] within ~/.aws/config
+#    * `pip install boto3` or `python3 -m pip install boto3`
+#    * Set RUN_LOCAL, RUN_UPDATE, and STAGE appropriately
+#    * run the script (`python3 pitr_recovery.py`)
+# Target localhost:8000, won't go up to AWS if True
+RUN_LOCAL = False
+# Prefix for the environment (master/val/production)
+STAGE = "master"
+STATE_FORMS_TABLE = "-state-forms"  # 5.3 k forms, 2.6MB
+ANSWERS_TABLE = "-form-answers"  # 120k answers, 97MB
+FILENAME = STAGE + "-missing.txt"
+
+
+def main():
+    # Config db connection
+    dynamodb = None
+    stage = STAGE
+    if RUN_LOCAL:
+        dynamodb = boto3.resource(
+            'dynamodb', endpoint_url='http://localhost:8000')
+        stage = "local"
+    else:
+        dynamodb = boto3.resource('dynamodb')
+
+    missing = find_missing_answers(stage, dynamodb)
+
+
+def find_missing_answers(stage, dynamodb):
+    print("Scanning State Forms")
+    state_forms_table = dynamodb.Table(stage + STATE_FORMS_TABLE)
+    answers_table = dynamodb.Table(stage + ANSWERS_TABLE)
+
+    state_forms = scan(state_forms_table)
+    print(" > Total Forms:", len(state_forms))
+
+    # For each form, check for answers, if one exists, break
+    # WB-2021-1-21E
+    # WV-2021-1-21E-1318-01
+    missing = []
+    for idx, form in enumerate(state_forms):
+        form_id = form['state_form']
+        expr = Attr('state_form').eq(form_id)
+        matching_answers = scan(
+            answers_table, FilterExpression=expr, first=True)
+        if len(matching_answers) <= 0:
+            missing.append(form_id)
+            print(f'{form_id}    [{idx}/{len(state_forms)}]')
+
+    print("--------------\n TOTAL MISSING", len(missing))
+    print(f"writing to {FILENAME}.txt")
+    text = "\n".join(missing)
+    with open(FILENAME, 'w') as f:
+        f.write(text)
+
+
+def scan(table, FilterExpression=None, first=False):
+    # Perform scan and execute a new batch for each 'LastEvaluatedKey'
+    if FilterExpression is not None:
+        response = table.scan(FilterExpression=FilterExpression)
+    else:
+        response = table.scan()
+    entries = response['Items']
+    total_scans = 1
+    while 'LastEvaluatedKey' in response:
+        total_scans += 1
+        # print("Batch", total_scans)
+        # print("  -- LastEvaluatedKey:",
+        #       response['LastEvaluatedKey'], "\nFilter:", FilterExpression)
+
+        # BATCH
+        if FilterExpression is not None:
+            response = table.scan(
+                FilterExpression=FilterExpression,
+                ExclusiveStartKey=response['LastEvaluatedKey'])
+        else:
+            response = table.scan(
+                ExclusiveStartKey=response['LastEvaluatedKey'])
+        entries.extend(response['Items'])
+        # Log details
+        # print("  -- Retrieved Count:", len(response['Items']))
+        if len(entries) > 0 and first:
+            break
+
+    return entries
+
+
+#### RUN #####
+if __name__ == "__main__":
+    start_time = time.time()
+    main()
+    print("--- %s seconds ---" % (time.time() - start_time))

--- a/scripts/form_answer_scan.py
+++ b/scripts/form_answer_scan.py
@@ -2,7 +2,7 @@ import boto3
 from boto3.dynamodb.conditions import Key, Attr
 import time
 
-# This script was created to load data from a PITR-created table after data loss on 3/23/23-3/24/23.
+# This script writes out text files of all state forms missing answers. Notably 64.ECI forms and 2020/2019 forms
 
 # Running this script:
 #    * Set the aws environment config file with the temporary values in [default] within ~/.aws/config

--- a/services/ui-src/src/components/FormLoadError/FormLoadError.js
+++ b/services/ui-src/src/components/FormLoadError/FormLoadError.js
@@ -5,7 +5,6 @@ import { Grid, GridContainer } from "@trussworks/react-uswds";
  * This generic error is created to prevent users from interacting with apps in a bad state.
  * - 64.ECI forms never have answers, and should be hidden going forward
  * - some 2019/2020 forms do not have answers, and the app is prone to display other answers when retrieved.
- * @returns
  */
 const FormLoadError = () => {
   return (

--- a/services/ui-src/src/components/FormLoadError/FormLoadError.js
+++ b/services/ui-src/src/components/FormLoadError/FormLoadError.js
@@ -1,0 +1,29 @@
+import React from "react";
+import { Grid, GridContainer } from "@trussworks/react-uswds";
+
+/**
+ * This generic error is created to prevent users from interacting with apps in a bad state.
+ * - 64.ECI forms never have answers, and should be hidden going forward
+ * - some 2019/2020 forms do not have answers, and the app is prone to display other answers when retrieved.
+ * @returns
+ */
+const FormLoadError = () => {
+  return (
+    <div className="formLoadError" data-testid="formLoadTest">
+      <GridContainer className="container">
+        <Grid row>
+          <Grid col={12}>
+            <h1>Error Retrieving Form</h1>
+            <p>
+              There was an issue loading the form, please contact the helpdesk
+              at{" "}
+              <a href="mailto:mdct_help@cms.hhs.gov">MDCT_Help@cms.hhs.gov</a>
+            </p>
+          </Grid>
+        </Grid>
+      </GridContainer>
+    </div>
+  );
+};
+
+export default FormLoadError;

--- a/services/ui-src/src/components/FormLoadError/FormLoadError.test.js
+++ b/services/ui-src/src/components/FormLoadError/FormLoadError.test.js
@@ -1,0 +1,23 @@
+import React from "react";
+import FormLoadError from "./FormLoadError";
+import { Grid, GridContainer } from "@trussworks/react-uswds";
+import { shallow } from "enzyme";
+
+describe("Test FormLoadError.js", () => {
+  const wrapper = shallow(<FormLoadError />);
+
+  test("Check the main element, with classname unauthorized, exists", () => {
+    expect(wrapper.find({ "data-testid": "formLoadTest" }).length).toBe(1);
+  });
+
+  test("Check that the component renders its child components", () => {
+    expect(wrapper.find(GridContainer).length).toBe(1);
+    expect(wrapper.find(Grid).length).toBe(2);
+  });
+
+  test("Check that there is an email help button", () => {
+    expect(
+      wrapper.find({ href: "mailto:mdct_help@cms.hhs.gov" }).text()
+    ).toMatch("MDCT_Help@cms.hhs.gov");
+  });
+});

--- a/services/ui-src/src/components/FormPage/FormPage.js
+++ b/services/ui-src/src/components/FormPage/FormPage.js
@@ -13,9 +13,10 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFilePdf } from "@fortawesome/free-solid-svg-icons";
 import { Button } from "@trussworks/react-uswds";
 import Unauthorized from "../Unauthorized/Unauthorized";
+import FormLoadError from "../FormLoadError/FormLoadError";
 import { getUserInfo } from "../../utility-functions/userFunctions";
 
-const FormPage = ({ getForm, statusData }) => {
+const FormPage = ({ getForm, statusData, loadError }) => {
   let history = useHistory();
 
   const [saveAlert, setSaveAlert] = React.useState(false);
@@ -81,7 +82,6 @@ const FormPage = ({ getForm, statusData }) => {
       setSaveAlert(false);
     }
   }, [last_modified]);
-
   return (
     <div className="react-transition fade-in" data-testid="FormPage">
       {save_error ? (
@@ -105,7 +105,7 @@ const FormPage = ({ getForm, statusData }) => {
           </Alert>
         </div>
       ) : null}
-      {hasAccess === true ? (
+      {hasAccess === true && !loadError ? (
         <>
           <div className="margin-x-5 margin-bottom-3">
             <FormHeader
@@ -139,6 +139,19 @@ const FormPage = ({ getForm, statusData }) => {
         </>
       ) : null}
       {hasAccess === false ? <Unauthorized /> : null}
+      {loadError ? (
+        <>
+          <div className="margin-x-5 margin-bottom-3">
+            <FormHeader
+              quarter={quarterInt}
+              form={formattedFormName}
+              year={year}
+              state={formattedStateName}
+            />
+          </div>
+          <FormLoadError />
+        </>
+      ) : null}
     </div>
   );
 };
@@ -149,7 +162,8 @@ FormPage.propTypes = {
 };
 
 const mapState = state => ({
-  statusData: state.currentForm.statusData
+  statusData: state.currentForm.statusData,
+  loadError: state.currentForm.loadError
 });
 
 const mapDispatch = {

--- a/services/ui-src/src/components/NotApplicable/NotApplicable.js
+++ b/services/ui-src/src/components/NotApplicable/NotApplicable.js
@@ -96,7 +96,7 @@ const NotApplicable = ({
         </p>
 
         <RangeInput
-          onChange={() => changeStatus()}
+          onInput={() => changeStatus()}
           id="range-slider"
           name="range"
           min={0}

--- a/services/ui-src/src/components/Quarterly/Quarterly.js
+++ b/services/ui-src/src/components/Quarterly/Quarterly.js
@@ -29,8 +29,10 @@ const Quarterly = () => {
         userStates.includes(state) ||
         currentUserInfo.Items[0].role === "admin"
       ) {
-        const data = await recursiveGetStateForms({ state, year, quarter });
-
+        let data = await recursiveGetStateForms({ state, year, quarter });
+        // Filter 64.ECI out on the user side, as it is an unused form and renders improperly
+        data = data.filter(i => i.form !== "64.ECI");
+        console.log(data);
         setStateFormsList(data);
         setHasAccess(true);
       } else {

--- a/services/ui-src/src/store/reducers/singleForm/singleForm.js
+++ b/services/ui-src/src/store/reducers/singleForm/singleForm.js
@@ -26,6 +26,7 @@ import { recursiveGetStateForms } from "../../../utility-functions/dbFunctions";
 
 // ACTION TYPES
 export const LOAD_SINGLE_FORM = "LOAD_SINGLE_FORM";
+export const LOAD_FORM_FAILURE = "LOAD_FORM_FAILURE";
 export const UPDATE_FORM_STATUS = "UPDATE_FORM_STATUS";
 export const UPDATE_APPLICABLE_STATUS = "UPDATE_APPLICABLE_STATUS";
 export const UPDATE_ANSWER = "UPDATE_ANSWER";
@@ -54,6 +55,11 @@ export const gotFormData = formObject => {
   return {
     type: LOAD_SINGLE_FORM,
     formObject
+  };
+};
+export const loadFormFailure = () => {
+  return {
+    type: LOAD_FORM_FAILURE
   };
 };
 export const gotAnswer = (answerArray, questionID) => {
@@ -127,7 +133,6 @@ export const clearFormData = (user = "cleared") => {
         deepCopy.last_modified_by = username;
         return deepCopy;
       });
-
       dispatch(clearedForm(emptyForm));
     } catch (error) {
       console.log("Error:", error);
@@ -175,6 +180,7 @@ export const getFormData = (state, year, quarter, formName) => {
       // Dispatch action creator to set data in redux
       dispatch(gotFormData(allFormData));
     } catch (error) {
+      dispatch(loadFormFailure());
       console.log("Error:", error);
       console.dir(error);
     }
@@ -257,7 +263,8 @@ const initialState = {
   questions: [],
   answers: [],
   statusData: {},
-  tabs: []
+  tabs: [],
+  loadError: false
 };
 
 // REDUCER
@@ -283,7 +290,13 @@ export default (state = initialState, action) => {
         questions: action.formObject.questions,
         answers: action.formObject.answers,
         statusData: action.formObject.statusData,
-        tabs: action.formObject.tabs
+        tabs: action.formObject.tabs,
+        loadError: false
+      };
+    case LOAD_FORM_FAILURE:
+      return {
+        ...state,
+        loadError: true
       };
     case UPDATE_APPLICABLE_STATUS:
       return {

--- a/services/ui-src/src/store/reducers/singleForm/singleForm.test.js
+++ b/services/ui-src/src/store/reducers/singleForm/singleForm.test.js
@@ -29,7 +29,8 @@ const initialState = {
   questions: [],
   answers: [],
   statusData: {},
-  tabs: []
+  tabs: [],
+  loadError: false
 };
 
 describe("Single Form Reducer, default values", () => {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
SEDS Help Desk Issues:

#### Some forms are missing entries in the answers table.
- All 64.ECI
- Some 2019/2020 forms. A txt file with the missing items has been attached to the relevant ticket in JIRA. Many of these are part of the legacy import.

Changes:
- When viewing quarterly, ECI forms should no longer appear in the list
- If a user does manage to view a form without answer entries in the table, displays an error recommending they contact the help desk.
- Also includes a script for generating the list of missing items, not deployed, just a useful snippet.

#### Applicable / Not Applicable Toggle not working
USWDS Slider Component is ignoring onChange despite documentation listing it. OnInput() works. I have questions about if there's a more appropriate component to use for a toggle, but it works now if you click on the opposite side of the toggle.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2742
MDCT-2743

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Run SEDS locally, an ECI form should not appear in the quarterly list
- Navigate to the ECI form manually or comment out the filter to see the behavior when a failed request occurs. Example URL: http://localhost:3000/#/forms/AL/2022/1/64-ECI
- Navigate to another form, use the toggle for Applicable/Not Applicable

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
