### PR TITLE
Update destroy script to cleanup hanging resources, and delete correctly

### DIFF
--- a/destroy.sh
+++ b/destroy.sh
@@ -77,7 +77,6 @@ fi
 
 for i in "${bucketList[@]}"
 do
-  echo $i
   set -e
 
   # Suspend bucket versioning.
@@ -106,26 +105,63 @@ do
   fi
 
   # Empty the bucket
+  echo "emptying bucket: $i"
   aws s3 rm s3://$i/ --recursive
 done
-
-echo "Removing certificate from stage"
 
 restApiName=$stage-app-api
 
 restApiId=$(aws apigateway get-rest-apis | jq -r ".[] | .[] |  select(.name==\"$restApiName\") | .id|tostring")
 
-aws apigateway update-stage \
-  --rest-api-id $restApiId \
-  --stage-name $stage \
-  --patch-operations op=replace,path=/clientCertificateId,value="" \
-  &>/dev/null
+if [ "$restApiId" != "" ]; then
+  echo "Removing certificate from stage"
 
-echo "Removed certificate from stage"
+  aws apigateway update-stage \
+    --rest-api-id $restApiId \
+    --stage-name $stage \
+    --patch-operations op=replace,path=/clientCertificateId,value="" \
+    &>/dev/null
+
+  restApiArn="arn:aws:apigateway:us-east-1::/restapis/$restApiId/stages/$stage"
+
+  echo "Disassociating web acl from api gateway"
+
+  aws wafv2 disassociate-web-acl \
+    --resource-arn $restApiArn &>/dev/null
+
+  echo "Removed certificate from stage and disassociated web acl"
+fi
 
 # Trigger a delete for each cloudformation stack
 for i in "${stackList[@]}"
 do
-  echo $i
+  echo "triggering stack deletion for $i"
   aws cloudformation delete-stack --stack-name $i
 done
+
+# Delete Client Certificates associated with a branch
+certToDestroy=$(aws apigateway get-client-certificates | grep \"app-api-${stage}\" -B 2 |
+  grep -o '"clientCertificateId": "[^"]*' |
+  grep -o '[^"]*$')
+
+until [ -z $certToDestroy ]; do
+  aws apigateway delete-client-certificate --client-certificate-id $certToDestroy || true
+  sleep 10
+  certToDestroy=$(aws apigateway get-client-certificates | grep \"app-api-${stage}\" -B 2 |
+    grep -o '"clientCertificateId": "[^"]*' |
+    grep -o '[^"]*$' || true)
+done
+
+# Find hanging api-gateway log group
+apiGatewayLogGroupName="/aws/api-gateway/app-api-$stage"
+apiGatewayLogGroupExists=($(aws logs describe-log-groups --log-group-name-prefix $apiGatewayLogGroupName | jq -r ".logGroups[] | length"))
+if [[ -n $apiGatewayLogGroupExists ]]; then
+  aws logs delete-log-group --log-group-name $apiGatewayLogGroupName
+fi
+
+# Find hanging api-gateway execution logs
+apiGatewayExecutionLogRegex="^API-Gateway-Execution-Logs[^/]+\/$stage$"
+apiGatewayExecutionLogs=($(aws logs describe-log-groups --query "logGroups[*].logGroupName" --output json | jq -r --arg pattern "$apiGatewayExecutionLogRegex" '.[] | select(test($pattern))'))
+if [[ -n $apiGatewayExecutionLogs ]]; then
+  aws logs delete-log-group --log-group-name $apiGatewayExecutionLogs
+fi


### PR DESCRIPTION
### Description
Destroy script didn't get all resources, and often failed on some stack deletions

### How to test
- Create your own branch and let it deploy
- Run this script locally and ensure everything deletes as expected
  - Open Kion
  - Get short-term access tokens for SEDS dev (MDCT dev account) and paste them in your terminal
  - From SEDS root execute `./destroy {branch name here}`
  - Once it lists all resources, repaste your branch name to start the destroy
  - Make sure script does not error
    - Also can track resources in AWS to make sure they go away...


Where to look
- Cloudformation
  - Search for your branch name and see stacks get removed (app-api and ui take the longest)
  - Make sure they actually get status "Delete completed" (or something like that), and not fail to delete
- Api Gateway
  - Click on any api gateway -> client certificates and make sure the cert with your branch name gets deleted
- Cloudwatch -> Log groups
  - search for your branch name and make sure all groups with that name in it get deleted


### Important updates
Won't take affect on branches until it's merged
