### PR TITLE
[MDCT-2841] Add optional param to lambda to regenerate missing answers per quarter

### DIFF
--- a/services/app-api/handlers/shared/sharedFunctions.js
+++ b/services/app-api/handlers/shared/sharedFunctions.js
@@ -205,6 +205,23 @@ export async function getFormResultByStateString(stateFormString) {
   return result.Items;
 }
 
+// Return a map of all stateFormIds within the answers table for use when repairing old data sets
+export async function getAnswersSet() {
+  console.log("Building set of state forms with answers");
+  const params = {
+    TableName:
+      process.env.FORM_ANSWERS_TABLE_NAME ?? process.env.FormAnswersTableName,
+  };
+
+  const result = await dynamoDb.scanMapToSet(
+    params,
+    (answer) => answer.state_form
+  );
+  console.log("- Done building set");
+
+  return result;
+}
+
 export async function findExistingStateForms(specifiedYear, specifiedQuarter) {
   const params = {
     TableName:

--- a/services/app-api/libs/dynamodb-lib.js
+++ b/services/app-api/libs/dynamodb-lib.js
@@ -37,6 +37,23 @@ export default {
     }
     return { Items: items, Count: items.length };
   },
+  scanMapToSet: async (params, mapFunction) => {
+    let itemSet = new Set();
+    let complete = false;
+    while (!complete) {
+      const result = await client.scan(params).promise();
+      if (!result.Items) continue;
+
+      itemSet = new Set([
+        ...itemSet,
+        ...result.Items.map((x) => mapFunction(x)),
+      ]);
+
+      params.ExclusiveStartKey = result.LastEvaluatedKey;
+      complete = result.LastEvaluatedKey === undefined;
+    }
+    return itemSet;
+  },
   batchWrite: (params) => client.batchWrite(params).promise(),
   listTables: (params) => database.listTables(params).promise(),
   increment: (params) =>

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -517,7 +517,7 @@ functions:
       - schedule:
           enabled: true
           rate: cron(0 0 1 JAN,APR,JUL,OCT ? *)
-    timeout: 800
+    timeout: 900
   stateUsersEmail:
     handler: handlers/notification/stateUsers.main
     role: LambdaApiRole


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Adds an optional flag to generateQuarterForms to allow the process to look for forms missing answers. See MDCT-2841 and related tickets on more details around which entries are missing.

This parameter is able to be invoked in the lambda but is not added to the UI admin panel, due to the process running longer than the API Gateway timeout when looking for the reports to correct (about 89s).

Logging is added to show how many state forms, and how many answers are created in the process, a message if nothing new was needed, and individually logging out any answers created by the process that were missing.

The plan will be to back up the answer and state form tables and run the process with the flag.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2841
MDCT-2649

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Pull the branch down
- As an admin, Generate as many quarters as you see fit (for full runtime generate 2019 -> 2023).
- Using the local dynamodb ui, select a state form to query the answer table by (ex `CT-2020-2-21E`). View and delete all entries in the answers table.
- Run the generate forms on that quarter in the UI, verify nothing changes.
- Run the generate forms with the AWS CLI including the new flag, setting the params to the same desired year and quarter:
```
aws lambda invoke /dev/null --endpoint-url http://localhost:3002 --function-name app-api-local-generateQuarterForms --payload '{"body":{"year": 2020, "quarter": 3, "restoreMissingAnswers": true}}' --cli-binary-format raw-in-base64-out
```
- Check logs to see that the expected answers are included
- Refresh the scan of the local db to see those entries
- Check that they can now be visited without error in the UI

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
