### PR TITLE
Use concurrency instead of custom script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,9 @@ on:
       - "dependabot/**"
       - "!skipci*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 permissions:
   id-token: write
   contents: read
@@ -40,10 +43,6 @@ jobs:
         with:
           role-to-assume: ${{ env.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
-      - name: lock this branch to prevent concurrent builds
-        run: ./.github/github-lock.sh $branch_name
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: read .nvmrc
         id: node_version
         run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)


### PR DESCRIPTION
### Description
Updating the deploy step to use GitHub workflow's native concurrency instead of the custom lock script

This ensures deploys will only run on a given branch if there are no other deploy steps already running on that branch. Also means that the branch is no longer waiting on other, non-deploy, non-dependent steps to complete (saw this most with CodeQL on PRs)

Note: we made a similar [change in QMR](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/pull/1968/files#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3) recently and it's working great

[docs for concurrency](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#examples-using-concurrency-and-the-default-behavior)

---
### How to test
Push to a branch twice with this change and see how the second deploy sits in "Pending" until the first completes