### PR TITLE
[MDCT-2841] SEDS Generate Answers - Correct ID in script + Targets Question -05 fix

### DIFF
--- a/scripts/correct_templated_year.py
+++ b/scripts/correct_templated_year.py
@@ -13,7 +13,7 @@ import time
 #    * run the script (`python3 correct_null_responses.py`)
 
 RUN_LOCAL = True                        # Target localhost:8000
-RUN_UPDATE = True                       # Dispatch updates for detected changes
+RUN_UPDATE = False                       # Dispatch updates for detected changes
 STAGE = "master"                        # Prefix for the environment
 TABLE = "-form-answers"  # "-form-answers" and "-form-questions" should be corrected
 TARGET_YEAR = "2019"     # "$..[?(@.question=='2020-21E-04')].rows[1].col2",

--- a/scripts/correct_templated_year.py
+++ b/scripts/correct_templated_year.py
@@ -1,0 +1,100 @@
+import boto3
+from boto3.dynamodb.conditions import Attr
+import time
+
+# This script was created to address null values in the seds reports, and set them as 0 for accessibility reasons.
+# Items should display as 0 for screen readers, and not have a heap of empty cells
+# This script will modify every entry in the row column with "rows.col*" entries from {"NULL": True} -> {"N": "0"}
+#
+# Running this script:
+#    * Set the aws environment config file with the temporary values in [default] within ~/.aws/config
+#    * pip install boto3
+#    * Set RUN_LOCAL, RUN_UPDATE, and STAGE appropriately
+#    * run the script (`python3 correct_null_responses.py`)
+
+RUN_LOCAL = True                        # Target localhost:8000
+RUN_UPDATE = True                       # Dispatch updates for detected changes
+STAGE = "master"                        # Prefix for the environment
+TABLE = "-form-answers"  # "-form-answers" and "-form-questions" should be corrected
+TARGET_YEAR = "2019"     # "$..[?(@.question=='2020-21E-04')].rows[1].col2",
+INCORRECT_YEAR = "2021"  # "$..[?(@.question=='2021-21E-04')].rows[1].col2",
+
+
+def main():
+    # Config db connection
+    dynamodb = None
+    stage = STAGE
+    if RUN_LOCAL:
+        dynamodb = boto3.resource(
+            'dynamodb', endpoint_url='http://localhost:8000')
+        stage = "local"
+    else:
+        dynamodb = boto3.resource('dynamodb')
+    print("Updating ", stage + TABLE)
+    table = dynamodb.Table(stage + TABLE)
+
+    # Perform scan and execute a new batch for each 'LastEvaluatedKey'
+    filter_ex = Attr(
+        "question").contains(TARGET_YEAR) & Attr(
+        "question").contains("-05")  # targets only appear in q 5
+    response = table.scan(FilterExpression=filter_ex)
+    updates = process_response(response)
+    total_scans = 1
+    while 'LastEvaluatedKey' in response:
+        total_scans += 1
+        print("Batch", total_scans)
+        print("  -- LastEvaluatedKey:", response['LastEvaluatedKey'])
+
+        # BATCH
+        response = table.scan(FilterExpression=filter_ex,
+                              ExclusiveStartKey=response['LastEvaluatedKey'])
+        modified = process_response(response)
+        updates.extend(modified)
+
+        # Log details
+        print("  -- IN PROGRESS: Changed Count:", len(modified),
+              "/", len(response['Items']))
+
+    print("  -- Final Changed Count:", len(updates))
+    # Execute Changes
+    if RUN_UPDATE:
+        update(table, updates)
+
+
+def process_response(response):
+    items = response['Items']
+    corrections = [correct_responses(i) for i in items]
+    changed = [updated_item for (
+        updated_item, modified) in corrections if modified == True]
+    return changed
+
+
+def correct_responses(item):
+    changes = False
+    for row in item["rows"]:
+        for key in [k for k in row]:
+            # Check that the entry in the row object for a key is actually a column, and not a header string
+            if type(key) != str or not key.startswith('col') or type(row[key]) == str:
+                continue
+            for entry in row[key]:
+                for i, val in enumerate(entry["targets"]):
+                    if INCORRECT_YEAR in val:
+                        changes = True
+                    entry["targets"][i] = val.replace(
+                        INCORRECT_YEAR, TARGET_YEAR)
+    return item, changes
+
+
+def update(table, changed):
+    print("Preparing Batch")
+    with table.batch_writer() as writer:
+        for item in changed:
+            writer.put_item(Item=item)
+    print("Batch executed")
+
+
+#### RUN #####
+if __name__ == "__main__":
+    start_time = time.time()
+    main()
+    print("--- %s seconds ---" % (time.time() - start_time))

--- a/services/app-api/handlers/forms/post/generateQuarterForms.js
+++ b/services/app-api/handlers/forms/post/generateQuarterForms.js
@@ -70,7 +70,7 @@ export const main = handler(async (event, context) => {
             { key: "1964", label: "Age 19 years through age 64 years" },
           ];
           break;
-        case "64-21E":
+        case "64.21E":
           ageRanges = [
             { key: "0001", label: "Birth through age 12 months" },
             { key: "0105", label: "Age 1 year through age 5 years" },
@@ -87,7 +87,7 @@ export const main = handler(async (event, context) => {
             { key: "1318", label: "Age 13 years through age 18 years" },
           ];
           break;
-        case "64-EC":
+        case "64.EC":
           ageRanges = [
             { key: "0001", label: "Birth through age 12 months" },
             { key: "0105", label: "Age 1 year through age 5 years" },
@@ -250,7 +250,7 @@ export const main = handler(async (event, context) => {
 
   // Add All StateForm Descriptions
   const putRequestsFormAnswers = [];
-  const stateAnswersSet = restoreMissingAnswers ? await getAnswersSet() : null;
+  const stateAnswersSet = restoreMissingAnswers ? await getAnswersSet() : null; //
 
   // Loop through all states, then all questions to return a new record with correct state info
   for (const state in allStates) {

--- a/services/app-api/handlers/forms/post/generateQuarterForms.js
+++ b/services/app-api/handlers/forms/post/generateQuarterForms.js
@@ -250,7 +250,7 @@ export const main = handler(async (event, context) => {
 
   // Add All StateForm Descriptions
   const putRequestsFormAnswers = [];
-  const stateAnswersSet = restoreMissingAnswers ? await getAnswersSet() : null; //
+  const stateAnswersSet = restoreMissingAnswers ? await getAnswersSet() : null;
 
   // Loop through all states, then all questions to return a new record with correct state info
   for (const state in allStates) {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
PR contains 3 files, broken down below.

#### Generate Forms corrections
The id's in the state forms are with `.` not `-`, and this change reflects that.

Question Table entry:
```json
{
 "question": "2020-64.21E-01",
 "column_total": true,
 "created_by": "seed",
 "created_date": "2020-01-15T12:46:35.838Z",
 "form": "64.21E",
...
 }
 ```

The generation script pulls the `64.21E` out of the question ID, and tries to key off it in the switch statement, but misses, never finds age ranges, and never generates answers for the user.

---

#### Data Correction Script

Based heavily on the null correction script, this addresses an issue in environments where the "targets" in question 5 are referencing IDs with the wrong year. The templates in those environments were long since corrected, but the outdated entries in the questions table still track 2021 for 2020 and 2019. 

The script is intended to run against both the questions and answers tables. This causes the Summary page in SEDS from crashing on load, and if it didn't crash it just wouldn't work anyway.

The bad state of the data looks something like this, note the question ID vs targets:
```json
{
  "age_range": "Age 13 years through age 18 years",
  "rangeId": "1318",
  "question": "2019-64.21E-05",
  "state_form": "KY-2019-1-64.21E",
  "last_modified_by": "seed",
  "created_date": "2023-09-13T13:20:48.720Z",
  "rows": [
    {
      "col6": "% of FPL 301-317",
      "col4": "% of FPL 201-250",
      "col5": "% of FPL 251-300",
      "col2": "% of FPL 0-133",
      "col3": "% of FPL 134-200",
      "col1": ""
    },
    {
      "col6": [
        {
          "targets": [
            "$..[?(@.question=='2021-64.21E-04')].rows[1].col6",
            "$..[?(@.question=='2021-64.21E-01')].rows[1].col6"
          ],
          "actions": [
            "formula"
          ],
          "formula": "<0> / <1>"
        }
      ],
}
```

---

#### Form Scan

This just outputs the state of the targetted env to text files, looking for forms without answers, and vice versa, along with some extra metrics now about the number of each report type per quarter.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2841

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Gen Quarters: I don't even know. Copy the production question templates into the local db then try to generate quarters 2019/2020? Then verify items generate for the two targeted forms?

Correction script: Copy down bad data from prod, or generate a 2019-2020 entry, and manually misalign the year. Run the script, and only the question(s) you changed should be modified.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
