### PR TITLE
correct group name for admin

### DIFF
--- a/services/ui-auth/libs/users.json
+++ b/services/ui-auth/libs/users.json
@@ -20,7 +20,7 @@
       },
       {
         "Name": "custom:ismemberof",
-        "Value": "CHIP_D_ADMIN_GROUP"
+        "Value": "CHIP_D_USER_GROUP_ADMIN"
       }
     ]
   },


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Correct the group attribute for the admin user. This is already manually corrected in seds dev cognito and tested, reflecting in the seed doc.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
--

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Should be able to successfully log into seds dev with adminuser@test.com


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
