### PR TITLE
update action versions

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Dependabotbot Gather Metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.3.0
+        uses: dependabot/fetch-metadata@v1
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,16 +39,13 @@ jobs:
           STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
           SEED_DATABASE: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_SEED_DATABASE] }}
       - name: Configure AWS credentials for GitHub Actions OIDC
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
-      - name: read .nvmrc
-        id: node_version
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
+          node-version-file: ".nvmrc"
       - uses: actions/cache@v3
         with:
           path: |
@@ -64,7 +61,7 @@ jobs:
         run: yarn install
       - name: unit test & publish coverage
         if: env.CODE_CLIMATE_ID != ''
-        uses: paambaati/codeclimate-action@v2.7.5
+        uses: paambaati/codeclimate-action@v5
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_ID }}
         with:
@@ -103,7 +100,7 @@ jobs:
           npm run test:ci
           popd
       - name: Store test reults
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test_results
           path: tests/nightwatch/tests_output

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -33,7 +33,7 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
           STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
       - name: Configure AWS credentials for GitHub Actions OIDC
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}

--- a/.github/workflows/git-secrets.yaml
+++ b/.github/workflows/git-secrets.yaml
@@ -4,8 +4,8 @@ jobs:
   gitleaks-scan:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Run gitlakes docker	    
-      uses: docker://zricethezav/gitleaks
-      with:
-        args: detect --source /github/workspace/ --no-git --verbose
+      - uses: actions/checkout@v3
+      - name: Run gitleaks docker
+        uses: docker://zricethezav/gitleaks
+        with:
+          args: detect --source /github/workspace/ --no-git --verbose

--- a/.github/workflows/scan_security-hub-jira-integration.yml
+++ b/.github/workflows/scan_security-hub-jira-integration.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: ${{ secrets.PRODUCTION_SYNC_OIDC_ROLE }}

--- a/.github/workflows/scan_snyk-jira-integration.yml
+++ b/.github/workflows/scan_snyk-jira-integration.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Snyk and Run Snyk test
         run: |
@@ -31,7 +31,7 @@ jobs:
     if: github.event_name == 'schedule'
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Snyk and Run Snyk test
         run: |


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Updating versions to avoid warnings and deprecations

Note: these have already been tested in [another PR](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/pull/1982) and I'm migrating them here

DOCS:
[aws-configure-credentials readme](https://github.com/aws-actions/configure-aws-credentials) – no breaking changes between 1 and 4. ("By default, your account ID will not be masked in workflow logs. This was changed from being masked by default in the previous version. AWS does not consider account IDs as sensitive information, so this change reflects that stance." Let me know if you want to mask this still and I'll add that option)
[cache readme](https://github.com/actions/cache) – no breaking changes with v3
[codeclimate action changelog](https://github.com/paambaati/codeclimate-action/releases) – breaking changes not relevant to us
[node version action](https://github.com/actions/setup-node) – update allows us to read from .nvmrc natively
[actions/checkout changelog](https://github.com/actions/checkout/releases/tag/v3.0.0) – v3 uses node 16 which will be deprecated soon but doesn't have a warning for now, and keeps it up to date with our other checkouts@v3
[dependabot/fetch-metadata action changelog](https://github.com/dependabot/fetch-metadata/releases) – specifically by changing to @v1 it will automatically use latest version

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-none

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
All steps here pass
View the step summaries and notice no deprecation warnings (compare to main or other branches)

[Failing deploy](https://github.com/Enterprise-CMCS/macpro-mdct-seds/actions/runs/6384944744/job/17328645282?pr=14741) is due to cypress which is fixed in a [separate PR](https://github.com/Enterprise-CMCS/macpro-mdct-seds/pull/14742)