### PR TITLE
Add security headers

### DIFF
--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -206,6 +206,9 @@ resources:
               Cookies:
                 Forward: none
             ViewerProtocolPolicy: redirect-to-https
+            FunctionAssociations:
+              - EventType: viewer-response
+                FunctionARN: !GetAtt HstsCloudfrontFunction.FunctionMetadata.FunctionARN
           ViewerCertificate:
             Fn::If:
               - CreateCustomCloudFrontDomain
@@ -232,6 +235,21 @@ resources:
           HostedZoneId: Z2FDTNDATAQYW2
           EvaluateTargetHealth: false
         Type: A
+    HstsCloudfrontFunction:
+      Type: AWS::CloudFront::Function
+      Properties:
+        AutoPublish: true
+        FunctionCode: |
+          function handler(event) {
+            var response = event.response;
+            var headers = response.headers;
+            headers['strict-transport-security'] = { value: 'max-age=63072000; includeSubdomains; preload'};
+            return response;
+          }
+        FunctionConfig:
+          Comment: This function adds headers to implement HSTS
+          Runtime: cloudfront-js-1.0
+        Name: hsts-${self:custom.stage}
     ###############This code block enables logging on waf and sends all logs to s3.##################################
     Firehose:
       Type: AWS::KinesisFirehose::DeliveryStream

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -208,7 +208,7 @@ resources:
             ViewerProtocolPolicy: redirect-to-https
             FunctionAssociations:
               - EventType: viewer-response
-                FunctionARN: !GetAtt HstsCloudfrontFunction.FunctionMetadata.FunctionARN
+                FunctionARN: !GetAtt HeadersCloudfrontFunction.FunctionMetadata.FunctionARN
           ViewerCertificate:
             Fn::If:
               - CreateCustomCloudFrontDomain
@@ -235,7 +235,7 @@ resources:
           HostedZoneId: Z2FDTNDATAQYW2
           EvaluateTargetHealth: false
         Type: A
-    HstsCloudfrontFunction:
+    HeadersCloudfrontFunction:
       Type: AWS::CloudFront::Function
       Properties:
         AutoPublish: true
@@ -244,6 +244,7 @@ resources:
             var response = event.response;
             var headers = response.headers;
             headers['strict-transport-security'] = { value: 'max-age=63072000; includeSubdomains; preload'};
+            headers['x-frame-options'] = { value: 'DENY' };
             return response;
           }
         FunctionConfig:

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -248,9 +248,9 @@ resources:
             return response;
           }
         FunctionConfig:
-          Comment: This function adds headers to implement HSTS
+          Comment: This function adds headers to implement various web security measures
           Runtime: cloudfront-js-1.0
-        Name: hsts-${self:custom.stage}
+        Name: security-headers-${self:custom.stage}
     ###############This code block enables logging on waf and sends all logs to s3.##################################
     Firehose:
       Type: AWS::KinesisFirehose::DeliveryStream


### PR DESCRIPTION
### Description
This PR adds several HTTP headers when serving the website:
* One which instructs browsers _only_ to interact with us via HTTPS
* One which instructs browsers not to serve our content within an iframe

The structure of the function to add these headers is identical to that of our other 4 apps: CARTS, QMR, MCR, MFP

### Related ticket(s)
CMDCT-271, CMDCT-308

---
### How to test
We don't use iframes to serve this website, so this PR shouldn't change anything. A quick smoke test (as provided by Cypress) should be sufficient.

It will also be good to inspect the network tab when loading the site for the first time. The new headers should be present on the response.

### Important updates
n/a

---
### Author checklist

- [x] I have performed a self-review of my code
- ~[ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary~
- ~[ ] I have updated relevant documentation, if necessary~

