### PR TITLE
Fail destroy action if no infrastructure is found for given stage

### DIFF
--- a/destroy.sh
+++ b/destroy.sh
@@ -33,6 +33,16 @@ set -e
 # Find cloudformation stacks associated with stage
 stackList=(`aws cloudformation describe-stacks | jq -r ".Stacks[] | select(.Tags[] | select(.Key==\"STAGE\") | select(.Value==\"$stage\")) | .StackName"`)
 
+if [ ${#stackList[@]} -eq 0 ]; then
+    echo """
+      ---------------------------------------------------------------------------------------------
+      ERROR: No stacks were identified for destruction
+      ---------------------------------------------------------------------------------------------
+      Please verify the stage name:  $stage
+    """
+    exit 1
+fi
+
 # Find buckets attached to any of the stages, so we can empty them before removal.
 bucketList=()
 set +e


### PR DESCRIPTION
### Description
When a branch is deleted, the destroy action is triggered and the latest commit on the default branch, in this case `master` is used to execute the destroy action.  In order to test that I can force a destroy action to fail, I need to actually execute the destroy action against the changed code.  This essentially means I have to get this PR merged into master before I can test this code.  It's definitely not ideal, but it's a very minor change.  Once this is done, I can verify that failures to match will indeed fail, and then I can finish the rest of the work to extract the branch name setting logic and verify the action can successfully match dependabot and snyk generated branches against their interpolated stage names.

Note, this will not close the related ticket, but is the first step in validating.

The purpose of this change is to stop having green destroy actions that didn't actually do anything, masking the fact that we're leaking infrastructure.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3218

---
### How to test
Because of how this work, this can't be tested until it's merged into the default branch.  This is not ideal, but it's just how GHA runners work.

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
