### PR TITLE
Fix snykdependa destroy

### DIFF
--- a/.github/setBranchName.sh
+++ b/.github/setBranchName.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+GITHUB_REF="${1}"
+
+[ -z "${GITHUB_REF}" ] && echo "Error setting branch name.  No input given." && exit 1
+
+case ${GITHUB_REF} in
+  $([[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]] && echo ${GITHUB_REF}))
+    echo ${GITHUB_REF##*/*-} | md5sum | head -c 10 | sed 's/^/x/'
+    ;;
+  $([[ "$GITHUB_REF" =~ ^refs/.*/snyk-* ]] && echo ${GITHUB_REF}))
+    echo ${GITHUB_REF##*/*-} | head -c 10 | sed 's/^/s/'
+    ;;
+  *)
+    echo ${GITHUB_REF#refs/heads/}
+    ;;
+esac

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,21 +20,14 @@ jobs:
     steps:
       - name: set branch_name # Some integrations (Dependabot & Snyk) build very long branch names. This is a switch to make long branch names shorter.
         run: |
-          echo "GITHUB_REF=${GITHUB_REF}"        
-          if [[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]]; then
-            echo "branch_name=`echo ${GITHUB_REF##*/*-} | md5sum | head -c 10 | sed 's/^/x/'`" >> $GITHUB_ENV
-          elif [[ "$GITHUB_REF" =~ ^refs/.*/snyk-* ]]; then
-            echo "branch_name=`echo ${GITHUB_REF##*/*-} | head -c 10 | sed 's/^/s/'`" >> $GITHUB_ENV
-          else
-            echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-          fi
+          echo "branch_name=$(./.github/setBranchName.sh ${GITHUB_REF})" >> $GITHUB_ENV
       - uses: actions/checkout@v3
       - name: Validate branch name
         run: ./.github/branchNameValidation.sh $STAGE_PREFIX$branch_name
       - name: set branch specific variable names
         run: ./.github/build_vars.sh set_names
       - name: set variable values
-        run: ./.github/build_vars.sh set_values
+        run: ./.github/build_vars.sh set_values && exit 1
         env:
           AWS_OIDC_ROLE_TO_ASSUME: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,9 @@ jobs:
     steps:
       - name: set branch_name # Some integrations (Dependabot & Snyk) build very long branch names. This is a switch to make long branch names shorter.
         run: |
-          ./.github/setBranchName.sh ${GITHUB_REF}
-          echo "branch_name=$(./.github/setBranchName.sh ${GITHUB_REF})" >> $GITHUB_ENV
+          ls -alh .github
+          BRANCH_NAME=$(./.github/setBranchName.sh ${GITHUB_REF})
+          echo "branch_name=${BRANCH_NAME}" >> $GITHUB_ENV
       - uses: actions/checkout@v3
       - name: Validate branch name
         run: ./.github/branchNameValidation.sh $STAGE_PREFIX$branch_name

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - name: set branch_name # Some integrations (Dependabot & Snyk) build very long branch names. This is a switch to make long branch names shorter.
         run: |
+          echo "GITHUB_REF=${GITHUB_REF}"
           echo "branch_name=$(./.github/setBranchName.sh ${GITHUB_REF})" >> $GITHUB_ENV
       - uses: actions/checkout@v3
       - name: Validate branch name

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,12 +18,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: set branch_name # Some integrations (Dependabot & Snyk) build very long branch names. This is a switch to make long branch names shorter.
         run: |
-          ls -alh .github
+          ls -alh
           BRANCH_NAME=$(./.github/setBranchName.sh ${GITHUB_REF})
           echo "branch_name=${BRANCH_NAME}" >> $GITHUB_ENV
-      - uses: actions/checkout@v3
       - name: Validate branch name
         run: ./.github/branchNameValidation.sh $STAGE_PREFIX$branch_name
       - name: set branch specific variable names

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: set branch_name # Some integrations (Dependabot & Snyk) build very long branch names. This is a switch to make long branch names shorter.
         run: |
-          echo "GITHUB_REF=${GITHUB_REF}"
+          ./.github/setBranchName.sh ${GITHUB_REF}
           echo "branch_name=$(./.github/setBranchName.sh ${GITHUB_REF})" >> $GITHUB_ENV
       - uses: actions/checkout@v3
       - name: Validate branch name

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: set branch_name # Some integrations (Dependabot & Snyk) build very long branch names. This is a switch to make long branch names shorter.
         run: |
-          ls -alh
           BRANCH_NAME=$(./.github/setBranchName.sh ${GITHUB_REF})
           echo "branch_name=${BRANCH_NAME}" >> $GITHUB_ENV
       - name: Validate branch name
@@ -29,7 +28,7 @@ jobs:
       - name: set branch specific variable names
         run: ./.github/build_vars.sh set_names
       - name: set variable values
-        run: ./.github/build_vars.sh set_values && exit 1
+        run: ./.github/build_vars.sh set_values
         env:
           AWS_OIDC_ROLE_TO_ASSUME: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -18,13 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: set branch_name
-        #This is the old code, and we want to test the failure condition
-        run: | 
-          if [[ "${{ github.event.ref }}" =~ ^dependabot/.* ]]; then # Dependabot builds very long branch names.  This is a switch to make it shorter.
-            echo "branch_name=`echo ${{ github.event.ref }} | md5sum | head -c 10 | sed 's/^/x/'`" >> $GITHUB_ENV
-          else
-            echo "branch_name=${{ github.event.ref }}" >> $GITHUB_ENV
-          fi
+        run: |
+          BRANCH_NAME=$(./.github/setBranchName.sh ${GITHUB_REF})
+          echo "branch_name=${BRANCH_NAME}" >> $GITHUB_ENV
       - name: set branch specific variable names
         run: ./.github/build_vars.sh set_names
       - name: set variable values

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -16,14 +16,15 @@ jobs:
     if: github.event.ref_type == 'branch' && !contains(fromJson('["master", "val", "production"]'), github.event.ref)
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: set branch_name
-        run: |
+        #This is the old code, and we want to test the failure condition
+        run: | 
           if [[ "${{ github.event.ref }}" =~ ^dependabot/.* ]]; then # Dependabot builds very long branch names.  This is a switch to make it shorter.
             echo "branch_name=`echo ${{ github.event.ref }} | md5sum | head -c 10 | sed 's/^/x/'`" >> $GITHUB_ENV
           else
             echo "branch_name=${{ github.event.ref }}" >> $GITHUB_ENV
           fi
-      - uses: actions/checkout@v3
       - name: set branch specific variable names
         run: ./.github/build_vars.sh set_names
       - name: set variable values

--- a/destroy.sh
+++ b/destroy.sh
@@ -33,6 +33,16 @@ set -e
 # Find cloudformation stacks associated with stage
 stackList=(`aws cloudformation describe-stacks | jq -r ".Stacks[] | select(.Tags[] | select(.Key==\"STAGE\") | select(.Value==\"$stage\")) | .StackName"`)
 
+if [ ${#stackList[@]} -eq 0 ]; then
+    echo """
+      ---------------------------------------------------------------------------------------------
+      ERROR: No stacks were identified for destruction
+      ---------------------------------------------------------------------------------------------
+      Please verify the stage name:  $stage
+    """
+    exit 1
+fi
+
 # Find buckets attached to any of the stages, so we can empty them before removal.
 bucketList=()
 set +e


### PR DESCRIPTION
### Description
This PR fixes two specific issues:

1. The Snyk integration implemented a change which was applied to the deploy action, which shortens auto-generated branches to a consumable length.  Dependabot already had a case in place to do this, but the change altered how Dependabot branches were interpolated into stage names, thus breaking the ability of the destroy action to correctly match infrastructure with a branch.  This caused infrastructure to leak.
2. Destroy actions did not fail when no infrastructure was identified.  Therefore successfully executed destroy actions did not indicate whether or not the action successfully destroyed the associated infrastructure.

There is a bit of a conundrum with this PR, in that it can't be tested in full until it's merged into master.   This is because destruction of a branch triggers destroy to run on the default branch, which is generally `master` or `main`.  Each component was tested individually, but the full CI run cannot be validated until this is merged in.  


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3218

---
### How to test
Each component has been validated individually, but should be tested in entirety once this is merged in.

Branch from `master`, and create three branches to exercise every condition.
`dependabot/npm_and_yarn/berry-did-this` (will be interpolated to stage as `x9e7b964750 `)
`snyk-upgrade-berry-did-this9faf06c882b46cc4a8e83` (will be interpolated to stage as `sthis9faf06`)
`berry-actual-change` (will be the same stage as branch name)

Let the builds go through, then delete the branches
Verify the infrastructure is successfully destroyed


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
This change will need to be propagated to every other product once verified.

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
