### PR TITLE
CMDCT-3185 - SSM Param for Cognito Pools

### DIFF
--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -267,6 +267,18 @@ resources:
                         - - ${self:custom.attachments_bucket_arn}/private/
                           - "$"
                           - "{cognito-identity.amazonaws.com:sub}/*"
+    CognitoUserPoolIdParameter:
+      Type: AWS::SSM::Parameter
+      Properties:
+        Name: /${self:custom.stage}/ui-auth/cognito_user_pool_id
+        Type: String
+        Value: !Ref CognitoUserPool
+    CognitoUserPoolClientIdParameter:
+      Type: AWS::SSM::Parameter
+      Properties:
+        Name: /${self:custom.stage}/ui-auth/cognito_user_pool_client_id
+        Type: String
+        Value: !Ref CognitoUserPoolClient
   Outputs:
     UserPoolId:
       Value: !Ref CognitoUserPool


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Exports the user pool info as a param the same way our other apps do. `authorization.ts` is already expecting this format, once this is deployed the dev env should pick it up.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
[CMDCT-3185](https://jiraent.cms.gov/browse/CMDCT-3185)

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
This deployment shouldn't crash and burn and should resolve master after merging. The expected ssm params should appear in aws console.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
