### PR TITLE
MDCT-3185 - Use correct casing for env stage

### DIFF
--- a/services/app-api/libs/authorization.js
+++ b/services/app-api/libs/authorization.js
@@ -63,7 +63,7 @@ function storeCognitoValuesInEnvironment(values) {
 
 async function loadCognitoValuesFromAws() {
   const ssm = new SSM();
-  const stage = process.env.stage;
+  const stage = process.env.STAGE;
   const getValue = async (identifier) => {
     const response = await ssm.getParameter({
       Name: `/${stage}/ui-auth/${identifier}`,


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Use the `process.env.STAGE` casing that is used elsewhere (kafka-lib).

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3185

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
