### PR TITLE
CMDCT-3185 - Allow API endpoints to use SSM vars

### DIFF
--- a/services/app-api/libs/authorization.js
+++ b/services/app-api/libs/authorization.js
@@ -72,8 +72,8 @@ async function loadCognitoValuesFromAws() {
     return response?.Parameter?.Value;
   };
 
-  const userPoolId = await getValue("cognito_user_pool_id");
-  const clientId = await getValue("cognito_user_pool_client_id");
+  const userPoolId = await getValue("cognito_user_pool_id").promise();
+  const clientId = await getValue("cognito_user_pool_client_id").promise();
 
   if (!userPoolId || !clientId) {
     throw new Error("cannot load cognito values");

--- a/services/app-api/libs/authorization.js
+++ b/services/app-api/libs/authorization.js
@@ -68,6 +68,7 @@ async function loadCognitoValuesFromAws() {
     const response = await ssm.getParameter({
       Name: `/${stage}/ui-auth/${identifier}`,
     });
+    console.log("requesting from ssm", response);
     return response?.Parameter?.Value;
   };
 

--- a/services/app-api/libs/authorization.js
+++ b/services/app-api/libs/authorization.js
@@ -63,7 +63,7 @@ function storeCognitoValuesInEnvironment(values) {
 
 async function loadCognitoValuesFromAws() {
   const ssm = new SSM();
-  const stage = process.env.STAGE;
+  const stage = process.env.stage;
   const getValue = async (identifier) => {
     const response = await ssm
       .getParameter({

--- a/services/app-api/libs/authorization.js
+++ b/services/app-api/libs/authorization.js
@@ -65,15 +65,17 @@ async function loadCognitoValuesFromAws() {
   const ssm = new SSM();
   const stage = process.env.STAGE;
   const getValue = async (identifier) => {
-    const response = await ssm.getParameter({
-      Name: `/${stage}/ui-auth/${identifier}`,
-    });
+    const response = await ssm
+      .getParameter({
+        Name: `/${stage}/ui-auth/${identifier}`,
+      })
+      .promise();
     console.log("requesting from ssm", response);
     return response?.Parameter?.Value;
   };
 
-  const userPoolId = await getValue("cognito_user_pool_id").promise();
-  const clientId = await getValue("cognito_user_pool_client_id").promise();
+  const userPoolId = await getValue("cognito_user_pool_id");
+  const clientId = await getValue("cognito_user_pool_client_id");
 
   if (!userPoolId || !clientId) {
     throw new Error("cannot load cognito values");

--- a/services/app-api/libs/authorization.js
+++ b/services/app-api/libs/authorization.js
@@ -70,7 +70,6 @@ async function loadCognitoValuesFromAws() {
         Name: `/${stage}/ui-auth/${identifier}`,
       })
       .promise();
-    console.log("requesting from ssm", response);
     return response?.Parameter?.Value;
   };
 

--- a/services/app-api/libs/kafka-source-lib.js
+++ b/services/app-api/libs/kafka-source-lib.js
@@ -1,7 +1,7 @@
 import AWS from "aws-sdk";
 const { Kafka } = require("kafkajs");
 
-const STAGE = process.env.STAGE;
+const STAGE = process.env.stage;
 const kafka = new Kafka({
   clientId: `seds-${STAGE}`,
   brokers: process.env.BOOTSTRAP_BROKER_STRING_TLS.split(","),

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -668,6 +668,10 @@ resources:
                   Action:
                     - lambda:InvokeFunction
                   Resource: "*"
+                - Effect: "Allow"
+                  Action:
+                    - ssm:GetParameter
+                  Resource: "*"
     KafkaSecurityGroup:
       Type: AWS::EC2::SecurityGroup
       Properties:

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -168,6 +168,7 @@ provider:
     AuthUserStatesTableName: ${env:AUTH_USER_STATES_TABLE_NAME, cf:database-${self:custom.stage}.AuthUserStatesTableName}
     AuthUserStatesTableArn: ${env:AUTH_USER_STATES_TABLE_ARN, cf:database-${self:custom.stage}.AuthUserStatesTableArn}
     SteamVersion: ".v0"
+    stage: ${self:custom.stage}
 
 functions:
   ForceKafkaSync:


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Allow API endpoints to use SSM vars, this is used for getting the user pool info to verify a jwt.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3185

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
