### PR TITLE
CMDCT-3335: Disable Email Notifications for Uncertification

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -464,15 +464,6 @@ functions:
           method: get
           cors: true
           authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
-  uncertified:
-    handler: handlers/notification/uncertified.main
-    role: LambdaApiRole
-    events:
-      - http:
-          path: notification/uncertified
-          method: post
-          cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
   generateQuarterForms:
     handler: handlers/forms/post/generateQuarterForms.main
     role: LambdaApiRole
@@ -491,6 +482,7 @@ functions:
           enabled: true
           rate: cron(0 0 1 JAN,APR,JUL,OCT ? *)
     timeout: 900
+  #
   # NOTE: The SEDS business owners have requested that the email flow to users be disabled, but would like to be
   # able to re-enable it at a future point (see: https://bit.ly/3w3mVmT). For now, this handler will be commented out
   # and not removed.
@@ -520,6 +512,17 @@ functions:
   #     - schedule:
   #         enabled: false
   #         rate: cron(0 0 1 */3 ? *)
+  #
+  # uncertified:
+  #   handler: handlers/notification/uncertified.main
+  #   role: LambdaApiRole
+  #   events:
+  #     - http:
+  #         path: notification/uncertified
+  #         method: post
+  #         cors: true
+  #         authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+  #
   saveForm:
     handler: handlers/forms/post/saveForm.main
     role: LambdaApiRole

--- a/services/ui-src/src/components/CertificationTab/CertificationTab.js
+++ b/services/ui-src/src/components/CertificationTab/CertificationTab.js
@@ -83,17 +83,20 @@ const CertificationTab = ({
     return userRole;
   };
 
-  // NOTE: The SEDS business owners have requested that the email flow to users be disabled, but would like to be
-  // able to re-enable it at a future point (see: https://bit.ly/3w3mVmT). For now, this will be commented out and not removed.
-  // const sendEmailtoBo = async () => {
-  //   let userRole = await currentUserRole();
-  //   if (userRole === "state") {
-  //     let emailObj = {
-  //       formInfo: formStatus
-  //     };
-  //     await sendUncertifyEmail(emailObj);
-  //   }
-  // };
+  /* 
+    NOTE: The SEDS business owners have requested that the email flow to users be disabled, but would like to be
+    able to re-enable it at a future point (see: https://bit.ly/3w3mVmT). For now, this will be commented out and not removed.
+    
+    const sendEmailtoBo = async () => {
+      let userRole = await currentUserRole();
+      if (userRole === "state") {
+              let emailObj = {
+        formInfo: formStatus
+      };
+      await sendUncertifyEmail(emailObj);
+    }
+  };
+  */
 
   let certifyText;
 

--- a/services/ui-src/src/components/CertificationTab/CertificationTab.js
+++ b/services/ui-src/src/components/CertificationTab/CertificationTab.js
@@ -11,7 +11,7 @@ import { Auth } from "aws-amplify";
 import PropTypes from "prop-types";
 import "./CertificationTab.scss";
 import { dateFormatter } from "../../utility-functions/sortingFunctions";
-import { sendUncertifyEmail, obtainUserByEmail } from "../../libs/api";
+import { obtainUserByEmail } from "../../libs/api";
 import { saveForm } from "../../store/reducers/singleForm/singleForm";
 
 const CertificationTab = ({
@@ -61,7 +61,7 @@ const CertificationTab = ({
     if (window.confirm("Are you sure you want to uncertify this report?")) {
       await uncertify();
       saveForm();
-      await sendEmailtoBo();
+      // await sendEmailtoBo();
       setprovisionalButtonStatus(false);
       setfinalButtonStatus(false);
     }

--- a/services/ui-src/src/components/CertificationTab/CertificationTab.js
+++ b/services/ui-src/src/components/CertificationTab/CertificationTab.js
@@ -83,15 +83,17 @@ const CertificationTab = ({
     return userRole;
   };
 
-  const sendEmailtoBo = async () => {
-    let userRole = await currentUserRole();
-    if (userRole === "state") {
-      let emailObj = {
-        formInfo: formStatus
-      };
-      await sendUncertifyEmail(emailObj);
-    }
-  };
+  // NOTE: The SEDS business owners have requested that the email flow to users be disabled, but would like to be
+  // able to re-enable it at a future point (see: https://bit.ly/3w3mVmT). For now, this will be commented out and not removed.
+  // const sendEmailtoBo = async () => {
+  //   let userRole = await currentUserRole();
+  //   if (userRole === "state") {
+  //     let emailObj = {
+  //       formInfo: formStatus
+  //     };
+  //     await sendUncertifyEmail(emailObj);
+  //   }
+  // };
 
   let certifyText;
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Disabling the email notification flows for when a user uncertifies a report.
NOTE: As part of this ticket, the BOs have requested that these flows can be re-enabled, which is why it's being commented out as opposed to removed completely.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3335

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
N/A

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
