### PR TITLE
Lower char limit as dervived names cannot exceed 64 chars

### DIFF
--- a/.github/branchNameValidation.sh
+++ b/.github/branchNameValidation.sh
@@ -15,7 +15,7 @@ join_by() { local IFS='|'; echo "$*"; }
 #creates glob match to check for reserved words used in branch names which would trigger failures
 glob=$(join_by $(for i in ${reserved_words[@]}; do echo "^$i-|-$i$|-$i-|^$i$"; done;))
 
-if [[ ! $local_branch =~ $valid_branch ]] || [[ $local_branch =~ $glob ]] || [[ ${#local_branch} -gt 128 ]]; then
+if [[ ! $local_branch =~ $valid_branch ]] || [[ $local_branch =~ $glob ]] || [[ ${#local_branch} -gt 64 ]]; then
     echo """
      ------------------------------------------------------------------------------------------------------------------------------
      ERROR:  Please read below


### PR DESCRIPTION
Lower char limit as dervived names cannot exceed 64 chars.  This doesn't account for that limit, but snyk branches can be as long as 59 chars and they are interpolated during deployment so if this script is also used for part of a git hook, we would still want to be able to manually manipulate synk branches.

The original change for this ticket was merged before discovering the lower limit, so the rest of the applications have the new lower limit but this app needs to be adjusted to remain consistently configured.

### Related ticket(s)
CMDCT-3222

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
