### PR TITLE
[CMDCT-3440] Tealium Fixes

### DIFF
--- a/services/ui-src/public/index.html
+++ b/services/ui-src/public/index.html
@@ -59,7 +59,7 @@
     <!-- Tealium Analytics Tag Manager -->
     <script>
       var tealiumEnvMap = {
-        "mdctseds.cms.gov": "production",
+        "mdctseds.cms.gov": "prod",
         "mdctsedsval.cms.gov": "qa"
       };
       var tealiumEnv = tealiumEnvMap[window.location.hostname] || "dev";

--- a/services/ui-src/src/components/App/App.js
+++ b/services/ui-src/src/components/App/App.js
@@ -12,12 +12,11 @@ import { ensureUserExistsInApi } from "../../utility-functions/initialLoadFuncti
 import { fireTealiumPageView } from "../../utility-functions/tealium";
 
 function App() {
-  const { pathname, key } = useLocation();
+  const { pathname } = useLocation();
   const [isAuthenticating, setIsAuthenticating] = useState(true);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isAuthorized, setIsAuthorized] = useState(false);
   const [user, setUser] = useState();
-
   async function onLoad() {
     try {
       const token = (await Auth.currentSession()).getIdToken();
@@ -39,8 +38,9 @@ function App() {
 
   // fire tealium page view on route change
   useEffect(() => {
-    fireTealiumPageView(user, window.location.href, pathname);
-  }, [key, pathname, user]);
+    if (isAuthenticating) return;
+    fireTealiumPageView(isAuthenticated, window.location.href, pathname);
+  }, [pathname, isAuthenticating, isAuthenticated]);
 
   return (
     <div className="App react-transition fade-in">

--- a/services/ui-src/src/utility-functions/tealium.js
+++ b/services/ui-src/src/utility-functions/tealium.js
@@ -15,7 +15,7 @@ export const fireTealiumPageView = (isAuthenticated, url, pathname) => {
   const contentType = isReportPage ? "form" : "app";
   const sectionName = isReportPage ? pathname.split("/")[1] : "main app";
   const tealiumEnvMap = {
-    "mdctseds.cms.gov": "production",
+    "mdctseds.cms.gov": "production", // Different than the url value (index.html)
     "mdctsedsval.cms.gov": "qa"
   };
   const tealiumEnv = tealiumEnvMap[window.location.hostname] || "dev";

--- a/services/ui-src/src/utility-functions/tealium.js
+++ b/services/ui-src/src/utility-functions/tealium.js
@@ -1,4 +1,16 @@
-export const fireTealiumPageView = (user, url, pathname) => {
+const MAX_RETRY = 5;
+let lastUrl = "";
+
+export const fireTealiumPageView = (isAuthenticated, url, pathname) => {
+  /**
+   * This double-fires on the re-route from / to /login when unauthenticated or logging out
+   * - url (from window.location.href) and pathname (from react location hook) can be out of sync
+   * - url will be the new location in both instances, pathname will be one for each
+   * - We only want to consume one of them.
+   *  */
+  if (url === lastUrl) return;
+  lastUrl = url;
+
   const isReportPage = pathname.includes("form");
   const contentType = isReportPage ? "form" : "app";
   const sectionName = isReportPage ? pathname.split("/")[1] : "main app";
@@ -8,16 +20,24 @@ export const fireTealiumPageView = (user, url, pathname) => {
   };
   const tealiumEnv = tealiumEnvMap[window.location.hostname] || "dev";
   const { host: siteDomain } = url ? new URL(url) : null;
+  sendView({
+    content_language: "en",
+    content_type: contentType,
+    page_name: sectionName + ":" + pathname,
+    page_path: pathname,
+    site_domain: siteDomain,
+    site_environment: tealiumEnv,
+    site_section: sectionName,
+    logged_in: isAuthenticated
+  });
+};
+
+const sendView = (view, retry = 0) => {
   if (window.utag) {
-    window.utag.view({
-      content_language: "en",
-      content_type: contentType,
-      page_name: sectionName + ":" + pathname,
-      page_path: pathname,
-      site_domain: siteDomain,
-      site_environment: tealiumEnv,
-      site_section: sectionName,
-      logged_in: !!user
-    });
+    window.utag.view(view);
+  } else if (retry <= MAX_RETRY) {
+    setTimeout(() => {
+      sendView(view, retry + 1);
+    }, 250);
   }
 };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Update the logic around when to make tealium page view calls.
- The page would sometimes not report at all at /login. Race condition with retrieving and attaching the tealium script. Add simple retry logic X times to see if the script is attached, otherwise bail.
- The page double reported when logged in. The hook needs to only fire once loading the user permisions into memory settles. 
- Some extra logic to not double report the /login page on redirect from /
- Corrects the url param used when in production from `production` to `prod`. This is not the same as the site_environment flag, and the two have been flipped back and forth together in the past.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3440

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Add breakpoints to the tealium library, or the calls in tealium.js before the call goes out in `window.utag.view`, OR add logging when running locally to tealium.js.
- Each page view should only trigger one report.
- Pay extra attention to the login page and root url. The root url redirects to login and needed some massaging to only send once.

Happy to show how to test this better if necessary.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
