### PR TITLE
Shift Dev Dependencies

### DIFF
--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -47,9 +47,6 @@
     "fs-extra": "^8.1.0",
     "html-webpack-plugin": "^4.5.2",
     "html2canvas": "^1.0.0-rc.7",
-    "jest": "^27.5.1",
-    "jest-resolve": "24.9.0",
-    "jest-watch-typeahead": "0.4.2",
     "jsonpath": "^1.1.1",
     "jspdf": "^2.3.1",
     "mini-css-extract-plugin": "0.9.0",
@@ -100,7 +97,6 @@
     "url-loader": "2.3.0",
     "uswds": "^2.14.0",
     "webpack": "4.42.0",
-    "webpack-dev-server": "^4.8.0",
     "webpack-manifest-plugin": "2.2.0",
     "workbox-webpack-plugin": "4.3.1"
   },
@@ -194,11 +190,15 @@
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-prettier": "^3.3.1",
     "identity-obj-proxy": "^3.0.0",
+    "jest": "^27.5.1",
+    "jest-resolve": "24.9.0",
+    "jest-watch-typeahead": "0.4.2",
     "react-test-renderer": "^16.13.1",
     "redux-devtools": "^3.7.0",
     "redux-mock-store": "^1.5.4",
     "serverless-cloudfront-invalidate": "1.5.0",
     "serverless-plugin-scripts": "^1.0.2",
-    "serverless-s3-sync": "^1.14.4"
+    "serverless-s3-sync": "^1.14.4",
+    "webpack-dev-server": "^4.8.0"
   }
 }


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Moving Dev dependencies into dev dependencies, not used while running.
Noticed one in a snyk PR as vulnerable but
- They aren't used when running
- Upgrade is dependent on the next node version.

We can at least put them in the right spot.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
N/A

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Can still run and test locally, and actions run.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
