### PR TITLE
CF Custom Response

### DIFF
--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -248,7 +248,7 @@ resources:
               - CloudFrontDefaultCertificate: true
           CustomErrorResponses:
             - ErrorCode: 403
-              ResponseCode: 403
+              ResponseCode: 200
               ResponsePagePath: /index.html
           WebACLId: !GetAtt WafPluginAcl.Arn
           Logging:


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Navigating to a path other than root returns a 403, and returns the index.html from the s3 bucket, while still preserving path. This allows the react routing to pick up the path and judge what should render, however, it is noisy and adds confusion to the mix about what is actually an error on the page.

After merging validate login with IDM and other features continue to work.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
N/A

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
