### PR TITLE
Add workflow that creates scheduled job to audit AWS account

### DIFF
--- a/.github/audit-account.sh
+++ b/.github/audit-account.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -o pipefail -o nounset -u
+git fetch --all > /dev/null
+
+#Parse inputs
+case ${1-} in
+  "ci_active"|"ci_inactive"|"cf_other"|"untagged")
+    OP=${1-}
+    ;;
+  *)
+    echo "Error:  unkown operation"
+    echo "Usage: ${0} [ci_active|ci_inactive|cf_other|untagged] [resource_tagging_response|null]" && exit 1
+    ;;
+esac
+
+shift
+if [ ! -z "${1-}" ]; then
+  if [ -f "${1-}" ]; then
+    RESOURCES=$(<"${1-}")
+  else 
+    RESOURCES="${@-}"  
+  fi
+  jq empty <<< "${RESOURCES}"
+  [ "$?" != 0 ] && echo "Error:  supplied JSON is invalid." && echo ${RESOURCES} && exit 1  
+else
+  RESOURCES=$(aws resourcegroupstaggingapi get-resources)
+fi
+
+#Create array of objects with the branch name and the interpolated branch name (for bot created branches)
+get_branches () {
+ RAW_BRANCHES=$(git for-each-ref --format='%(refname)' refs/remotes/origin | sed 's|^.\+\/||g')
+ BRANCHES=()
+ for B in $RAW_BRANCHES; do
+   [ "${B}" == "HEAD" ] && continue
+   IBRANCH=$(./setBranchName.sh ${B})
+   BRANCHES+=($(echo '{"BRANCH":"'${B}'","IBRANCH":"'${IBRANCH}'"}'))
+ done
+
+ jq -s '{BRANCHES:.}' <<< ${BRANCHES[*]}
+}
+
+get_composite_ci () {
+  local BRANCHES=$(get_branches)
+  local RESOURCES=$(jq -r '{RESOURCES:[.ResourceTagMappingList[] | select(.Tags[]?.Key?=="STAGE")]}' <<< "${1}")
+  jq -rs 'reduce .[] as $item ({}; . * $item) 
+          | [JOIN(INDEX(.BRANCHES[]; .IBRANCH); .RESOURCES[]; .Tags[].Value; add)] 
+          | [.[] 
+          | {"BRANCH":.BRANCH, "STAGE":.Tags[] 
+          | select(.Key=="STAGE").Value, "ResourceARN":.ResourceARN}]' <<< $(echo ${BRANCHES}${RESOURCES})
+}
+
+#Produce report for active stacks created by the ci pipeline (has a corresponding branch)
+ci_active () {
+  jq -r '[.[] | select(.BRANCH != null)] | sort_by(.STAGE)' <<< $(get_composite_ci "${1}")
+}
+
+#Produce report for active stacks created by the ci pipeline (does NOT have a corresponding branch)
+ci_inactive () {
+  jq -r '[.[] | select(.BRANCH == null)] | del(.[].BRANCH) | sort_by(.STAGE)' <<< $(get_composite_ci "${1}")
+}
+
+#Produce report for resources that have tags but were not created by the ci pipeline
+cf_other () {
+  jq -r '[.ResourceTagMappingList[] | select((.Tags? | length) > 0) | del(select(.Tags[].Key=="STAGE")) // empty | 
+         {
+           InferredId: .Tags[] | select(.Key=="aws:cloudformation:stack-name" or .Key=="cms-cloud-service" or .Key=="Name").Value,
+           ResourceARN: .ResourceARN
+         }] | sort' <<< "${1}"
+}
+
+#Produce report for resources that are untagged (some are still created by the ci pipeline)
+untagged () {
+  jq -r '[{ResourceARN:.ResourceTagMappingList[] | select((.Tags? | length) < 1).ResourceARN}] | sort' <<< "${1}"
+}
+
+#Execute operation
+$OP "${RESOURCES}"

--- a/.github/workflows/audit-account.yml
+++ b/.github/workflows/audit-account.yml
@@ -57,7 +57,7 @@ jobs:
           [[ $(jq -r 'length' <<< "${UNTAGGED}") -gt 0 ]] && jq -r '(.[0] 
             | keys_unsorted) as $keys | $keys, map([.[ $keys[] ]])[] | @csv' <<< "${UNTAGGED}" > reports/untagged.csv
       - name: Upload reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: resource-reports
           path: .github/reports/

--- a/.github/workflows/audit-account.yml
+++ b/.github/workflows/audit-account.yml
@@ -1,0 +1,64 @@
+name: Audit Account
+
+on:
+  schedule:
+    - cron: "0 16 * * 1" # Every Monday at 1600 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.ref }}
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4  
+      - name: set variable values
+        run: ./.github/build_vars.sh set_values
+        env:
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_OIDC_ROLE_TO_ASSUME: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
+      - name: Configure AWS credentials for GitHub Actions
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+      - name: Collect resources from account
+        run: pushd .github && aws resourcegroupstaggingapi get-resources > resources.json
+      - name: List active resources created by CI pipeline
+        run: pushd .github && ./audit-account.sh ci_active resources.json
+      - name: List orphaned resources created by CI pipeline
+        run: pushd .github && ./audit-account.sh ci_inactive resources.json
+      - name: List resources created by Cloudformation but not from CI pipeline
+        run: pushd .github && ./audit-account.sh cf_other resources.json
+      - name: List untagged resources
+        run: pushd .github && ./audit-account.sh untagged resources.json            
+      - name: Create reports dir
+        run: pushd .github && mkdir -p reports
+      - name: Assemble CSV files
+        run: |
+          #!/bin/bash
+          pushd .github
+          echo "Reports with no entries will be omitted"
+          CI_ACTIVE="$(./audit-account.sh ci_active resources.json)"
+          [[ $(jq -r 'length' <<< "${CI_ACTIVE}") -gt 0 ]] && jq -r '(.[0] 
+            | keys_unsorted) as $keys | $keys, map([.[ $keys[] ]])[] | @csv' <<< "${CI_ACTIVE}" > reports/ci_active.csv
+          CI_INACTIVE="$(./audit-account.sh ci_inactive resources.json)"
+          [[ $(jq -r 'length' <<< "${CI_INACTIVE}") -gt 0 ]] && jq -r '(.[0] 
+            | keys_unsorted) as $keys | $keys, map([.[ $keys[] ]])[] | @csv' <<< "${CI_INACTIVE}" > reports/ci_inactive.csv
+          CF_OTHER="$(./audit-account.sh cf_other resources.json)"
+          [[ $(jq -r 'length' <<< "${CF_OTHER}") -gt 0 ]] && jq -r '(.[0] 
+            | keys_unsorted) as $keys | $keys, map([.[ $keys[] ]])[] | @csv' <<< "${CF_OTHER}" > reports/cf_other.csv
+          UNTAGGED="$(./audit-account.sh untagged resources.json)"
+          [[ $(jq -r 'length' <<< "${UNTAGGED}") -gt 0 ]] && jq -r '(.[0] 
+            | keys_unsorted) as $keys | $keys, map([.[ $keys[] ]])[] | @csv' <<< "${UNTAGGED}" > reports/untagged.csv
+      - name: Upload reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: resource-reports
+          path: .github/reports/
+          retention-days: 14


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This PR applies a scheduled infrastructure audit to this application which can be manually executed or be run on a cron.  For more information, see [this PR](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/pull/2148)


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3475

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
