### PR TITLE
Remove client certificates and fix run script

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "nightwatch": "3.1.2",
     "prettier": "2.2.1",
     "serverless": "^3.38.0",
-    "serverless-api-client-certificate": "^1.0.2",
     "serverless-bundle": "^6.0.0",
     "serverless-dotenv-plugin": "^4.0.0",
     "serverless-iam-helper": "github:Enterprise-CMCS/serverless-iam-helper",

--- a/run
+++ b/run
@@ -75,4 +75,4 @@ fi
 
 # build and run run.ts
 # tsc is configured to build what we expect in tsconfig.json
-./node_modules/.bin/tsc && node ./build_dev/run.js "${ARGS[@]}"
+./node_modules/.bin/tsc && node ./build_dev/run.js "${ARGS[@]-}"

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -14,7 +14,6 @@ plugins:
   - serverless-offline
   - serverless-associate-waf
   - serverless-stack-termination-protection
-  - serverless-api-client-certificate
   - serverless-iam-helper
   - serverless-offline-ssm
   - "@enterprise-cmcs/serverless-waf-plugin"
@@ -44,10 +43,6 @@ custom:
       - impl
       - val
       - prod
-  authValue:
-    master: aws_iam
-    val: aws_iam
-    production: aws_iam
   infrastructureType: ${env:INFRASTRUCTURE_TYPE, ssm:/configuration/${self:custom.stage}/infrastucture/type, ssm:/configuration/default/infrastucture/type, "development"}
   AgeRangesTableName: ${env:AGE_RANGES_TABLE_NAME, cf:database-${self:custom.stage}.AgeRangesTableName}
   AgeRangesTableArn: ${env:AGE_RANGES_TABLE_ARN, cf:database-${self:custom.stage}.AgeRangesTableArn}
@@ -88,9 +83,6 @@ custom:
   associateWaf:
     name: ${self:custom.webAclName}
     version: V2
-  serverlessApiClientCertificate:
-    rotateCerts: true
-    daysLeft: 30
   dataSubnets:
     - ${env:LOCAL_PLACEHOLDER_ARN, ssm:/configuration/${self:custom.stage}/vpc/subnets/kubernetes/a/id, ssm:/configuration/default/vpc/subnets/kubernetes/a/id, ""}
     - ${env:LOCAL_PLACEHOLDER_ARN, ssm:/configuration/${self:custom.stage}/vpc/subnets/kubernetes/b/id, ssm:/configuration/default/vpc/subnets/kubernetes/b/id, ""}
@@ -338,7 +330,7 @@ functions:
           path: export/export-to-excel
           method: post
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
   getUserById:
     handler: handlers/users/get/getUserById.main
     role: LambdaApiRole
@@ -347,7 +339,7 @@ functions:
           path: users/{id}
           method: get
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
   getUsers:
     handler: handlers/users/get/listUsers.main
     role: LambdaApiRole
@@ -356,7 +348,7 @@ functions:
           path: users
           method: get
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
   obtainUserByUsername:
     handler: handlers/users/post/obtainUserByUsername.main
     role: LambdaApiRole
@@ -365,7 +357,7 @@ functions:
           path: users/get
           method: post
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
   obtainUserByEmail:
     handler: handlers/users/post/obtainUserByEmail.main
     role: LambdaApiRole
@@ -374,7 +366,7 @@ functions:
           path: users/get/email
           method: post
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
   createUser:
     handler: handlers/users/post/createUser.main
     role: LambdaApiRole
@@ -383,7 +375,7 @@ functions:
           path: users/add
           method: post
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
   adminCreateUser:
     handler: handlers/users/post/createUser.adminCreateUser
     role: LambdaApiRole
@@ -392,7 +384,7 @@ functions:
           path: users/admin-add
           method: post
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
   deleteUser:
     handler: handlers/users/post/deleteUser.main
     role: LambdaApiRole
@@ -404,7 +396,7 @@ functions:
           path: users/update/{userId}
           method: post
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
   getForm:
     handler: handlers/forms/get.main
     role: LambdaApiRole
@@ -413,7 +405,7 @@ functions:
           path: single-form/{state}/{specifiedYear}/{quarter}/{form}
           method: get
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
   getStateFormList:
     handler: handlers/forms/post/obtainFormsList.main
     role: LambdaApiRole
@@ -422,7 +414,7 @@ functions:
           path: forms/obtain-state-forms
           method: post
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
   updateStateFormList:
     handler: handlers/state-forms/post/updateStateForms.main
     role: LambdaApiRole
@@ -431,7 +423,7 @@ functions:
           path: state-forms/update
           method: post
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
   generateEnrollmentTotals:
     handler: handlers/state-forms/post/generateEnrollmentTotals.main
     role: LambdaApiRole
@@ -440,7 +432,7 @@ functions:
           path: generate-enrollment-totals
           method: post
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
           async: true
     timeout: 900
   obtainAvailableForms:
@@ -451,7 +443,7 @@ functions:
           path: forms/obtainAvailableForms
           method: post
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
   getFormTypes:
     handler: handlers/forms/get/getFormTypes.main
     role: LambdaApiRole
@@ -460,7 +452,7 @@ functions:
           path: form-types
           method: get
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
   generateQuarterForms:
     handler: handlers/forms/post/generateQuarterForms.main
     role: LambdaApiRole
@@ -469,7 +461,7 @@ functions:
           path: generate-forms
           method: post
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
     timeout: 900
   generateQuarterFormsOnSchedule:
     handler: handlers/forms/post/generateQuarterForms.scheduled
@@ -492,7 +484,7 @@ functions:
   #         path: notification/stateUsersEmail
   #         method: post
   #         cors: true
-  #         authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+  #         authorizer: aws_iam
   #     - schedule:
   #         enabled: true
   #         rate: cron(0 0 1 */3 ? *)
@@ -505,7 +497,7 @@ functions:
   #         path: notification/businessUsersEmail
   #         method: post
   #         cors: true
-  #         authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+  #         authorizer: aws_iam
   #     - schedule:
   #         enabled: false
   #         rate: cron(0 0 1 */3 ? *)
@@ -518,7 +510,7 @@ functions:
   #         path: notification/uncertified
   #         method: post
   #         cors: true
-  #         authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+  #         authorizer: aws_iam
   #
   saveForm:
     handler: handlers/forms/post/saveForm.main
@@ -528,7 +520,7 @@ functions:
           path: single-form/save
           method: post
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
   getFormTemplate:
     handler: handlers/form-templates/post/obtainFormTemplate.main
     role: LambdaApiRole
@@ -537,7 +529,7 @@ functions:
           path: form-template
           method: post
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
   getFormTemplateYears:
     handler: handlers/form-templates/post/obtainFormTemplateYears.main
     role: LambdaApiRole
@@ -546,7 +538,7 @@ functions:
           path: form-templates/years
           method: post
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
   updateCreateFormTemplate:
     handler: handlers/form-templates/post/updateCreateFormTemplate.main
     role: LambdaApiRole
@@ -555,7 +547,7 @@ functions:
           path: form-templates/add
           method: post
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
 
 resources:
   Description: ${self:service} ${self:custom.stage}

--- a/src/run.ts
+++ b/src/run.ts
@@ -179,4 +179,5 @@ yargs(process.argv.slice(2))
     }
   )
   .scriptName("run")
+  .strict()
   .demandCommand(1, "").argv; // this prints out the help if you don't call a subcommand

--- a/yarn.lock
+++ b/yarn.lock
@@ -10973,11 +10973,6 @@ serialize-javascript@^6.0.1:
   dependencies:
     randombytes "^2.1.0"
 
-serverless-api-client-certificate@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/serverless-api-client-certificate/-/serverless-api-client-certificate-1.0.2.tgz#9113f3ad3862faf8615a37733ca09a1409ced8dd"
-  integrity sha512-snlEA1129NpZGYc0ra1eae17dKPYOXrju7cN+ku8roo6XOSMvNPe4XmEf0vVojoVHburXmI+Yx7y8DgJYeM2Fg==
-
 serverless-bundle@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/serverless-bundle/-/serverless-bundle-6.0.0.tgz#c2d3b6bb8fd1e0a49043af3a022673f7a03c8011"


### PR DESCRIPTION
### Description
It was noticed after the destroy action modifications, that AwsApiGateway Client Certificates were leaking and not being cleaned up.  Our previous destroy script had a specific action item to clean these certificates up, but because they had been leaking, the quota was overrun which was causing deployment issues.  

The initial effort to resolve included exploring the following:
- modifying the serverless stage destroyer to clean up certs;  this was abandonded when it was found that certs are not tagged and would have to be collected by namespace
- adding a custom resource that would be triggered by a Cloudformation stack event to clean them up

But after additional digging, it was appearing that the plugin used to manage the certs was in fact causing leaks, as each ephem would have two certs, with only one being bound to the Cloudformation template.  After even more digging, it didn't seem like they were even being used.  Additionally any SecHub findings would be addressed by simply not leaving the authorizer blank for ephem environments.  

This PR does two things:
- remove the client cert plugin from the yaml, remove it from the dependencies, and remove the switching for environments for Lambda authorizer, setting it to aws_iam to assert iam authentication between the api gateway and the function
- Fix the run script to ensure it can take no arguments, and will return all options when no arguments are supplied.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3743

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Simply click through the ephem to ensure it works as expected.  Issuing `run local` to test locally as well.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
Nothing should materially change.  The certs will need to be cleaned up manually at some point.  No new certs will be created.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
