### PR TITLE
Fix seed runner (for future use)

### DIFF
--- a/services/data-deployment/serverless.yml
+++ b/services/data-deployment/serverless.yml
@@ -61,7 +61,7 @@ custom:
         ]
     form-templates:
       table: ${self:custom.stage}-form-templates
-      sources: [../../src/database/initial_data_load/form_templates_2019.json]
+      sources: [../../src/database/initial_data_load/form_template_2019.json]
     form-answers:
       table: ${self:custom.stage}-form-answers
       sources:

--- a/services/data-deployment/serverless.yml
+++ b/services/data-deployment/serverless.yml
@@ -4,7 +4,6 @@ frameworkVersion: "3"
 
 plugins:
   - serverless-s3-bucket-helper
-  - serverless-plugin-scripts
   - serverless-dynamodb-seed
   - serverless-stack-termination-protection
 
@@ -125,8 +124,3 @@ custom:
     auth-user-roles:
       table: ${self:custom.stage}-auth-user-roles
       sources: [../../src/database/initial_data_load/auth_user_roles.json]
-
-  scripts:
-    hooks:
-      deploy:finalize: |
-        sls --stage ${self:custom.stage} dynamodb:seed

--- a/services/data-deployment/yarn.lock
+++ b/services/data-deployment/yarn.lock
@@ -23,8 +23,3 @@ serverless-dynamodb-seed@^0.3.0:
   integrity sha512-wwfFh4wwmisRnMlEkNjx/x4srVv01gkjCR8tCkEtEFColsZe3ROC8eX/yFZl/tebix1nK1xi1oQwGF6QqYVZyQ==
   dependencies:
     bluebird "^3.7.2"
-
-serverless-plugin-scripts@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/serverless-plugin-scripts/-/serverless-plugin-scripts-1.0.2.tgz#21808c3cfd0a1a84e48c0660b0f6f370b5665486"
-  integrity sha1-IYCMPP0KGoTkjAZgsPbzcLVmVIY=

--- a/src/run.ts
+++ b/src/run.ts
@@ -145,9 +145,17 @@ async function seed_database(
   const seedService = "data-deployment"
   await install_deps(runner, seedService);
   const seedDeployCmd = ["sls", "deploy", "--stage", stage];
+  // Deploy seed service
   await runner.run_command_and_output(
     "Seed service deploy",
     seedDeployCmd,
+    `services/${seedService}`
+  );
+  // Run seed
+  const seedCmd = ["sls", "--stage", stage, "dynamodb:seed"];
+  await runner.run_command_and_output(
+    "Run seed",
+    seedCmd,
     `services/${seedService}`
   );
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -143,7 +143,7 @@ async function seed_database(
   stage: string
 ) {
   const seedService = "data-deployment"
-  install_deps(runner, seedService);
+  await install_deps(runner, seedService);
   const seedDeployCmd = ["sls", "deploy", "--stage", stage];
   await runner.run_command_and_output(
     "Seed service deploy",
@@ -162,7 +162,7 @@ async function install_deps(runner: LabeledProcessRunner, service: string) {
 
 async function prepare_services(runner: LabeledProcessRunner) {
   for (const service of deployedServices) {
-    install_deps(runner, service);
+    await install_deps(runner, service);
   }
 }
 
@@ -173,9 +173,9 @@ async function deploy(options: { stage: string }) {
   const deployCmd = ["sls", "deploy", "--stage", stage];
   await runner.run_command_and_output("Serverless deploy", deployCmd, ".");
   // Seed when flag is set to true
-  if (process.env.SEED_DATABASE) {
-    seed_database(runner, stage);
-  }
+  // if (process.env.SEED_DATABASE) {
+  await seed_database(runner, stage);
+  // }
 }
 
 async function destroy_stage(options: {

--- a/src/run.ts
+++ b/src/run.ts
@@ -152,7 +152,7 @@ async function seed_database(
     `services/${seedService}`
   );
   // Run seed
-  const seedCmd = ["sls", "--stage", stage, "dynamodb:seed"];
+  const seedCmd = ["sls", "dynamodb:seed", "--stage", stage];
   await runner.run_command_and_output(
     "Run seed",
     seedCmd,

--- a/src/run.ts
+++ b/src/run.ts
@@ -181,9 +181,9 @@ async function deploy(options: { stage: string }) {
   const deployCmd = ["sls", "deploy", "--stage", stage];
   await runner.run_command_and_output("Serverless deploy", deployCmd, ".");
   // Seed when flag is set to true
-  // if (process.env.SEED_DATABASE) {
-  await seed_database(runner, stage);
-  // }
+  if (process.env.SEED_DATABASE) {
+    await seed_database(runner, stage);
+  }
 }
 
 async function destroy_stage(options: {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Note: The seed runner is currently not run in any environment. This PR purely fixes it such that it will not be a problem if we choose to use it in the future.

Test the conditionally-run seed command and fix issues with it so that it is ready to use when we want

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3645 continued

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
See the logs from the [first run](https://github.com/Enterprise-CMCS/macpro-mdct-seds/actions/runs/9979698828/job/27579367733) and verify that the seed script failed

Verify it then succeeds in [this run](https://github.com/Enterprise-CMCS/macpro-mdct-seds/actions/runs/9980341512/job/27581482844), once the seed command was moved to `run` and re-ordered

Note: the latest build will not run seed because the `if` logic will be reinstated.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
This branch changed the logic to ensure the data seed flow triggered. Normally this is triggered by a GitHub secret

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment