### PR TITLE
CMDCT-3726: experiment to update router to fix routing in seds

### DIFF
--- a/services/ui-src/src/components/Routes/Routes.jsx
+++ b/services/ui-src/src/components/Routes/Routes.jsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { Redirect, Switch } from "react-router-dom";
+import {React, useEffect} from "react";
+import { Redirect, Switch, useHistory, useLocation } from "react-router-dom";
 import Home from "../Home/Home";
 import Login from "../Login/Login";
 import NotFound from "../NotFound/NotFound";
@@ -21,6 +21,15 @@ import FormTemplates from "../FormTemplates/FormTemplates";
 import GenerateTotals from "../GenerateTotals/GenerateTotals";
 
 export default function Routes({ user, isAuthorized }) {
+  const history = useHistory()
+  const location = useLocation()
+  // Preserve old hash style urls and route them to adjusted urls
+  useEffect(() => {
+    if (location.hash && location.hash.startsWith('#/')) {
+      history.replace(location.hash.replace('#', ''))
+    }
+  }, [history, location.hash, location.pathname])
+
   if (!isAuthorized) {
     return (
       <Switch>

--- a/services/ui-src/src/index.jsx
+++ b/services/ui-src/src/index.jsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom";
 import "./index.scss";
 import App from "./components/App/App";
 import * as serviceWorker from "./serviceWorker";
-import { HashRouter as Router } from "react-router-dom";
+import { BrowserRouter as Router } from "react-router-dom";
 import { Amplify } from "aws-amplify";
 import config from "./config/config";
 import { Provider } from "react-redux";


### PR DESCRIPTION
### Description

This PR is to update SEDS from using `HashRouter` to `BrowserRouter`. The only thing this changes is that it removes the `#` from the url path. So instead of an url like `https://mdctsedsdev.cms.gov/#/forms/NC/2021/3`, it will now be `https://mdctsedsdev.cms.gov/forms/NC/2021/3` without the hash path. The routing functionality will still be the exact same. If users happen to have old urls saved with the hash in it, the router will properly route to the correct url without a hash.

On a side note, SEDS has an issue where when you log in with EUA login, it loads a blank page upon successful login. Unfortunately, this behavior is not re-createable locally because we can't do EUA logins locally so we're hoping to merge this to dev and see if it resolves that issue (my theory with that issue is that when you login with cognito, it takes you to the root url with the hash (`https://mdctsedsdev.cms.gov/#`) and if you login with EUA it takes you to the root URL without the hash (`https://mdctsedsdev.cms.gov/`). so I am hoping that removing hash functionality will just fix the issue)
