### PR TITLE
Set the Not Applicable toggle to the correct position on page load

### DIFF
--- a/services/ui-src/src/components/NotApplicable/NotApplicable.jsx
+++ b/services/ui-src/src/components/NotApplicable/NotApplicable.jsx
@@ -21,7 +21,7 @@ const NotApplicable = ({
   saveForm,
   updatedApplicableThunk
 }) => {
-  const [applicableStatus, setApplicableStatus] = useState(1); // 0 or 1
+  const [applicableStatus, setApplicableStatus] = useState(notApplicable ? 1 : 0);
   const [disableSlider, setDisableSlider] = useState(); // Should the slider be disabled?
 
   const determineUserRole = async () => {


### PR DESCRIPTION
### Description
This PR addresses a cosmetic glitch that caused the "Not Applicable" toggle on every form page to be switched on, regardless of the form data's actual state.

That is: even when the form was Applicable (and the "Active" label on the left side was correctly bolded), the slider would show on the right ("Not Applicable") side on initial page load.

### Related ticket(s)
CMDCT-

---
### How to test
1. Log in as a state user
2. Navigate to any editable form (that is, a form that has not already been certified)
   * Note that the "Does this form apply to your state" toggle is on the left side, and **Active** is bolded
3. Click the toggle, and confirm that you want to lose all the data on the page
   * Note that the toggle is on the right side, and **Not Applicable** is bolded
4. Refresh the page
   * Note that the toggle and bolding have not changed
5. Feel free to keep switching the toggle and refreshing the page. You should never be able to get the toggle out of sync with the data state.

If you ever see this, then the fix isn't working:
![image](https://github.com/user-attachments/assets/b4133455-ed7b-4f01-8265-97abe0105a7d)

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
   * No, but I will in an upcoming PR!
- ~[ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- ~[ ] These changes are significant enough to require an update to the SIA.~
- ~[ ] These changes are significant enough to require a penetration test.~
---

