### PR TITLE
CMDCT-3252: fixing issue with user setting state after admin unassigning state

### DIFF
--- a/services/ui-src/src/components/EditUser/EditUser.jsx
+++ b/services/ui-src/src/components/EditUser/EditUser.jsx
@@ -94,7 +94,7 @@ const EditUser = ({ stateList }) => {
       states = option.join("-");
     }
     if (!states) {
-      states = "null";
+      states = null;
     }
     setStatesToSend(states);
   };
@@ -122,7 +122,7 @@ const EditUser = ({ stateList }) => {
         setStatesToSend(newStates);
       } else {
         if (!e.value) {
-          e.value = "null";
+          e.value = null;
         }
         setStatesToSend([e.value]);
         response = e.value;
@@ -132,7 +132,7 @@ const EditUser = ({ stateList }) => {
     } else if (field === "role") {
       // Save to local state
       setRole(e.value);
-      setStatesToSend("null");
+      setStatesToSend(null);
       setSelectedStates();
       // Update user
       response = e.value;


### PR DESCRIPTION
### Description
There was a seds bug where if admin unassigned a user from a state (usually just by assigning the user to another role), upon next login of said user, there would be a 500 forbidden error when trying to select a state. This was due to a `"null"` string being passed into the state value instead of just good ol' `null`. 

All I did here was change from a "null" string to the actual null value and it resolved the issue. 


### Related ticket(s)
CMDCT-3252

---
### How to test
1. Pull down my `cmdct-3252` branch locally in seds and run locally
2. Log into seds as `adminuser@test.com`
3. Go to view/edit users
4. select a user that you have the credentials to log in with (look for the `stateuser@test.com` user) 
5. change the role of the user and make sure that when you Update User, there is no state selected
6. After the user has been logged in, log in as the user you just changed the role for
7. You should be prompted to pick a state. Select a state and make sure that the selection goes through and you are taken to another page where you can select years and quarters and so on. 