### PR TITLE
Allow for undefined values in user table export

### DIFF
--- a/services/ui-src/src/utility-functions/exportFunctions.js
+++ b/services/ui-src/src/utility-functions/exportFunctions.js
@@ -31,7 +31,7 @@ export const handleExcelExport = async (fileName, content) => {
  */
 export const buildCsvContents = content => {
   const escape = value => {
-    const str = value.toString();
+    const str = value?.toString() ?? "";
     return /[\r\n,]/.test(str) ? `"${str.replaceAll('"', '""')}"` : str;
   };
   const createRow = arr => arr.map(escape).join(",");

--- a/services/ui-src/src/utility-functions/exportFunctions.test.js
+++ b/services/ui-src/src/utility-functions/exportFunctions.test.js
@@ -47,14 +47,8 @@ describe("Export Functions", () => {
 
     it("should handle undefined properties in the data", async () => {
       const content = {
-        columns: [
-          { name: "Value", selector: "value" },
-        ],
-        data: [
-          { value: "foo" },
-          { },
-          { value: "bar" },
-        ],
+        columns: [{ name: "Value", selector: "value" }],
+        data: [{ value: "foo" }, {}, { value: "bar" }]
       };
 
       const fileContents = buildCsvContents(content);

--- a/services/ui-src/src/utility-functions/exportFunctions.test.js
+++ b/services/ui-src/src/utility-functions/exportFunctions.test.js
@@ -45,6 +45,23 @@ describe("Export Functions", () => {
       expect(fileContents).toBe("Name,Count\r\napple,3\r\norange,5");
     });
 
+    it("should handle undefined properties in the data", async () => {
+      const content = {
+        columns: [
+          { name: "Value", selector: "value" },
+        ],
+        data: [
+          { value: "foo" },
+          { },
+          { value: "bar" },
+        ],
+      };
+
+      const fileContents = buildCsvContents(content);
+
+      expect(fileContents).toBe("Value\r\nfoo\r\n\r\nbar");
+    });
+
     it("should properly escape fields when necessary", async () => {
       const content = {
         columns: [


### PR DESCRIPTION
### Description
Fixes error: `TypeError: Cannot read properties of undefined (reading 'toString')`

This error was not caught in development because our canned test data does not include any `undefined` values in the user list. The live environments sometimes do.

### Related ticket(s)
n/a

---
### How to test
This would be a real pain to actually test locally. I think you'd need to spin up the dynamo db admin page, then delete some of the properties from an object in the user table, and then follow the test instructions from #14948.

Frankly, I wouldn't.

### Notes
n/a


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
- ~[ ] I have performed a self-review of my code~
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- ~[ ] Design: This work has been reviewed and approved by design, if necessary~
- ~[ ] Product: This work has been reviewed and approved by product owner, if necessary~

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- ~[ ] These changes are significant enough to require an update to the SIA.~
- ~[ ] These changes are significant enough to require a penetration test.~
