### PR TITLE
update macfc security hub github action

### DIFF
--- a/.github/workflows/scan_security-hub-jira-integration.yml
+++ b/.github/workflows/scan_security-hub-jira-integration.yml
@@ -21,13 +21,12 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: ${{ secrets.PRODUCTION_SYNC_OIDC_ROLE }}
       - name: Sync Security Hub and Jira
-        uses: Enterprise-CMCS/mac-fc-security-hub-visibility@v1.0.5
+        uses: Enterprise-CMCS/mac-fc-security-hub-visibility@v2.0.9
         with:
           jira-username: "mdct_github_service_account"
           jira-token: ${{ secrets.JIRA_ENT_USER_TOKEN }}
-          jira-host: jiraent.cms.gov
           jira-project-key: CMDCT
           jira-ignore-statuses: Done, Closed, Canceled
           jira-custom-fields: '{ "customfield_10100": "CMDCT-2280", "customfield_26700" : [{"id": "40102", "value": "SEDS"}] }'
           aws-severities: CRITICAL, HIGH, MEDIUM
-          assign-jira-ticket-to: "MWTW"
+          jira-assignee: "MWTW"


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Based on tested work from [MFP](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/758)

I didn't see any new features that would be helpful for us. The biggest change seems to be allowing you to link issues, but we usually just link an epic and leave it at that.

References:
[Confluence upgrade guide](https://confluenceent.cms.gov/pages/viewpage.action?spaceKey=MDSO&title=Security+Hub+v2+Upgrade+Steps)
[README with available tags](https://github.com/Enterprise-CMCS/mac-fc-security-hub-visibility/blob/v2/README.md)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3994

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Run in main once merged

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- ~[ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary~
- ~[ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment