### PR TITLE
CMDCT-4186 - serverless side, prep dynamo tables so that they are retained

### DIFF
--- a/services/database/serverless.yml
+++ b/services/database/serverless.yml
@@ -48,9 +48,9 @@ provider:
   name: aws
   runtime: nodejs20.x
   region: us-east-1
-  stackTags:  
+  stackTags:
     PROJECT: ${self:custom.project}
-    SERVICE: ${self:service}  
+    SERVICE: ${self:service}
   versionFunctions: true
   iam:
     role:
@@ -91,6 +91,7 @@ resources:
   Resources:
     AgeRangesTable:
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:
         TableName: ${self:custom.stage}-age-ranges
         PointInTimeRecoverySpecification:
@@ -106,6 +107,7 @@ resources:
         BillingMode: PAY_PER_REQUEST # Set the capacity to auto-scale
     FormAnswersTable:
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:
         TableName: ${self:custom.stage}-form-answers
         PointInTimeRecoverySpecification:
@@ -131,6 +133,7 @@ resources:
               ProjectionType: ALL
     FormQuestionsTable:
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:
         TableName: ${self:custom.stage}-form-questions
         PointInTimeRecoverySpecification:
@@ -146,6 +149,7 @@ resources:
         BillingMode: PAY_PER_REQUEST # Set the capacity to auto-scale
     FormTemplatesTable:
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:
         TableName: ${self:custom.stage}-form-templates
         PointInTimeRecoverySpecification:
@@ -161,6 +165,7 @@ resources:
         BillingMode: PAY_PER_REQUEST # Set the capacity to auto-scale
     FormsTable:
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:
         TableName: ${self:custom.stage}-forms
         PointInTimeRecoverySpecification:
@@ -176,6 +181,7 @@ resources:
         BillingMode: PAY_PER_REQUEST # Set the capacity to auto-scale
     StateFormsTable:
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:
         TableName: ${self:custom.stage}-state-forms
         PointInTimeRecoverySpecification:
@@ -191,6 +197,7 @@ resources:
         BillingMode: PAY_PER_REQUEST # Set the capacity to auto-scale
     StatesTable:
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:
         TableName: ${self:custom.stage}-states
         PointInTimeRecoverySpecification:
@@ -206,6 +213,7 @@ resources:
         BillingMode: PAY_PER_REQUEST # Set the capacity to auto-scale
     StatusTable:
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:
         TableName: ${self:custom.stage}-status
         PointInTimeRecoverySpecification:
@@ -221,6 +229,7 @@ resources:
         BillingMode: PAY_PER_REQUEST # Set the capacity to auto-scale
     AuthUserTable:
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:
         TableName: ${self:custom.stage}-auth-user
         PointInTimeRecoverySpecification:
@@ -237,6 +246,7 @@ resources:
         BillingMode: PAY_PER_REQUEST # Set the capacity to auto-scale
     AuthUserRolesTable:
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:
         TableName: ${self:custom.stage}-auth-user-roles
         PointInTimeRecoverySpecification:
@@ -252,6 +262,7 @@ resources:
         BillingMode: PAY_PER_REQUEST # Set the capacity to auto-scale
     AuthUserStatesTable:
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:
         TableName: ${self:custom.stage}-auth-user-states
         PointInTimeRecoverySpecification:

--- a/services/database/serverless.yml
+++ b/services/database/serverless.yml
@@ -91,7 +91,6 @@ resources:
   Resources:
     AgeRangesTable:
       Type: AWS::DynamoDB::Table
-      DeletionPolicy: Retain
       Properties:
         TableName: ${self:custom.stage}-age-ranges
         PointInTimeRecoverySpecification:
@@ -213,7 +212,6 @@ resources:
         BillingMode: PAY_PER_REQUEST # Set the capacity to auto-scale
     StatusTable:
       Type: AWS::DynamoDB::Table
-      DeletionPolicy: Retain
       Properties:
         TableName: ${self:custom.stage}-status
         PointInTimeRecoverySpecification:
@@ -246,7 +244,6 @@ resources:
         BillingMode: PAY_PER_REQUEST # Set the capacity to auto-scale
     AuthUserRolesTable:
       Type: AWS::DynamoDB::Table
-      DeletionPolicy: Retain
       Properties:
         TableName: ${self:custom.stage}-auth-user-roles
         PointInTimeRecoverySpecification:
@@ -262,7 +259,6 @@ resources:
         BillingMode: PAY_PER_REQUEST # Set the capacity to auto-scale
     AuthUserStatesTable:
       Type: AWS::DynamoDB::Table
-      DeletionPolicy: Retain
       Properties:
         TableName: ${self:custom.stage}-auth-user-states
         PointInTimeRecoverySpecification:


### PR DESCRIPTION
### Description
For this serverless side change we are just making sure that dynamo tables are retained when the serverless stacks are destroyed.

### Related ticket(s)
CMDCT-4186

---
### How to test
Deploy the stack on this branch and see that it creates several serverless stacks. Then run the destroy command and see that it destroys lots of stuff but importantly not the dynamo tables.

### Notes
NA

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
