### PR TITLE
CMDCT-4194 cdk side, creating a better way to import resources from serverless including Cognito UserPool

### DIFF
--- a/deployment/app.ts
+++ b/deployment/app.ts
@@ -1,57 +1,62 @@
 #!/usr/bin/env node
 import "source-map-support/register";
 import * as cdk from "aws-cdk-lib";
+import { WithoutImportsParentStack } from "./stacks/without_imports/parent";
+import { WithImportsParentStack} from "./stacks/with_imports/parent";
 import { ParentStack } from "./stacks/parent";
 import { determineDeploymentConfig } from "./deployment-config";
 import { getSecret } from "./utils/secrets-manager";
 import { getDeploymentConfigParameters } from "./utils/systems-manager";
 
 async function main() {
-  try {
-    const app = new cdk.App({
-      defaultStackSynthesizer: new cdk.DefaultStackSynthesizer(
-        JSON.parse((await getSecret("cdkSynthesizerConfig"))!)
-      ),
-    });
+  const app = new cdk.App({
+    defaultStackSynthesizer: new cdk.DefaultStackSynthesizer(
+      JSON.parse((await getSecret("cdkSynthesizerConfig"))!)
+    ),
+  });
 
-    const stage = app.node.getContext("stage");
-    const config = await determineDeploymentConfig(stage);
+  const stage = app.node.getContext("stage");
+  const config = await determineDeploymentConfig(stage);
 
-    const parametersToFetch = {
-      cloudfrontCertificateArn: {
-        name: "cloudfront/certificateArn",
-        useDefault: true,
-      },
-      cloudfrontDomainName: {
-        name: "cloudfront/domainName",
-        useDefault: false,
-      },
-      vpnIpSetArn: { name: "vpnIpSetArn", useDefault: true },
-      vpnIpv6SetArn: { name: "vpnIpv6SetArn", useDefault: true },
-      hostedZoneId: { name: "route53/hostedZoneId", useDefault: true },
-      domainName: { name: "route53/domainName", useDefault: true },
-    };
+  const parametersToFetch = {
+    cloudfrontCertificateArn: {
+      name: "cloudfront/certificateArn",
+      useDefault: true,
+    },
+    cloudfrontDomainName: {
+      name: "cloudfront/domainName",
+      useDefault: false,
+    },
+    vpnIpSetArn: { name: "vpnIpSetArn", useDefault: true },
+    vpnIpv6SetArn: { name: "vpnIpv6SetArn", useDefault: true },
+    hostedZoneId: { name: "route53/hostedZoneId", useDefault: true },
+    domainName: { name: "route53/domainName", useDefault: true },
+  };
 
-    const deploymentConfigParameters = await getDeploymentConfigParameters(
-      parametersToFetch,
-      stage
-    );
+  const deploymentConfigParameters = await getDeploymentConfigParameters(
+    parametersToFetch,
+    stage
+  );
 
-    cdk.Tags.of(app).add("STAGE", stage);
-    cdk.Tags.of(app).add("PROJECT", config.project);
+  cdk.Tags.of(app).add("STAGE", stage);
+  cdk.Tags.of(app).add("PROJECT", config.project);
 
-    new ParentStack(app, `${config.project}-${stage}`, {
-      ...config,
-      env: {
-        account: process.env.CDK_DEFAULT_ACCOUNT,
-        region: process.env.CDK_DEFAULT_REGION,
-      },
-      deploymentConfigParameters,
-    });
-  } catch (error) {
-    console.error("Error:", error);
-    process.exit(1);
+  let correctParentStack;
+  if (process.env.WITHOUT_IMPORTS) {
+    correctParentStack = WithoutImportsParentStack
+  } else if (process.env.WITH_IMPORTS) {
+    correctParentStack = WithImportsParentStack
+  } else {
+    correctParentStack = ParentStack
   }
+  new correctParentStack(app, `${config.project}-${stage}`, {
+    ...config,
+    env: {
+      account: process.env.CDK_DEFAULT_ACCOUNT,
+      region: process.env.CDK_DEFAULT_REGION,
+    },
+    deploymentConfigParameters,
+  });
 }
 
 main();

--- a/deployment/stacks/data.ts
+++ b/deployment/stacks/data.ts
@@ -79,25 +79,28 @@ export function createDataComponents(props: CreateDataComponentsProps) {
         "service-role/AWSLambdaVPCAccessExecutionRole"
       ),
     ],
+    inlinePolicies: {
+      DynamoPolicy: new iam.PolicyDocument({
+        statements: [
+          new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: [
+              "dynamodb:DescribeTable",
+              "dynamodb:Query",
+              "dynamodb:Scan",
+              "dynamodb:GetItem",
+              "dynamodb:PutItem",
+              "dynamodb:UpdateItem",
+              "dynamodb:DeleteItem",
+            ],
+            resources: ["*"],
+          })
+        ]
+      })
+    },
     permissionsBoundary: props.iamPermissionsBoundary,
     path: props.iamPath,
   });
-
-  lambdaApiRole.addToPolicy(
-    new iam.PolicyStatement({
-      effect: iam.Effect.ALLOW,
-      actions: [
-        "dynamodb:DescribeTable",
-        "dynamodb:Query",
-        "dynamodb:Scan",
-        "dynamodb:GetItem",
-        "dynamodb:PutItem",
-        "dynamodb:UpdateItem",
-        "dynamodb:DeleteItem",
-      ],
-      resources: ["*"],
-    })
-  );
 
   // TODO: test deploy and watch performance with this using lambda.Function vs lambda_nodejs.NodejsFunction
   const seedDataFunction = new lambda_nodejs.NodejsFunction(scope, "seedData", {

--- a/deployment/stacks/parent.ts
+++ b/deployment/stacks/parent.ts
@@ -2,7 +2,7 @@ import { Construct } from "constructs";
 import {
   aws_ec2 as ec2,
   aws_iam as iam,
-  aws_ssm as ssm,
+  // aws_ssm as ssm,
   CfnOutput,
   Stack,
   StackProps,
@@ -14,7 +14,7 @@ import { createUiAuthComponents } from "./ui-auth";
 import { createUiComponents } from "./ui";
 import { createApiComponents } from "./api";
 import { sortSubnets } from "../utils/vpc";
-import { deployFrontend } from "./deployFrontend";
+// import { deployFrontend } from "./deployFrontend";
 import { createCustomResourceRole } from "./customResourceRole";
 
 export class ParentStack extends Stack {
@@ -65,7 +65,8 @@ export class ParentStack extends Stack {
       customResourceRole,
     });
 
-    const { apiGatewayRestApiUrl, restApiId } = createApiComponents({
+    // const { apiGatewayRestApiUrl, restApiId } = createApiComponents({
+      const { restApiId } = createApiComponents({
       ...commonProps,
       vpc,
       privateSubnets,
@@ -75,21 +76,22 @@ export class ParentStack extends Stack {
 
     const {
       applicationEndpointUrl,
-      cloudfrontDistributionId,
-      distribution,
-      s3BucketName,
-      uiBucket,
+      // cloudfrontDistributionId,
+      // distribution,
+      // s3BucketName,
+      // uiBucket,
     } = createUiComponents({
       deploymentConfigParameters,
       ...commonProps,
     });
 
-    const {
-      userPoolDomainName,
-      identityPoolId,
-      userPoolId,
-      userPoolClientId,
-    } = createUiAuthComponents({
+    // const {
+    //   userPoolDomainName,
+    //   identityPoolId,
+    //   userPoolId,
+    //   userPoolClientId,
+    // } =
+    createUiAuthComponents({
       ...commonProps,
       oktaMetadataUrl,
       applicationEndpointUrl,
@@ -98,33 +100,33 @@ export class ParentStack extends Stack {
       customResourceRole,
     });
 
-    deployFrontend({
-      ...commonProps,
-      uiBucket,
-      distribution,
-      apiGatewayRestApiUrl,
-      applicationEndpointUrl,
-      identityPoolId,
-      userPoolId,
-      userPoolClientId,
-      userPoolClientDomain: `${userPoolDomainName}.auth.${this.region}.amazoncognito.com`,
-      customResourceRole,
-    });
+    // deployFrontend({
+    //   ...commonProps,
+    //   uiBucket,
+    //   distribution,
+    //   apiGatewayRestApiUrl,
+    //   applicationEndpointUrl,
+    //   identityPoolId,
+    //   userPoolId,
+    //   userPoolClientId,
+    //   userPoolClientDomain: `${userPoolDomainName}.auth.${this.region}.amazoncognito.com`,
+    //   customResourceRole,
+    // });
 
-    new ssm.StringParameter(this, "DeploymentOutput", {
-      parameterName: `/${project}/${stage}/deployment-output`,
-      stringValue: JSON.stringify({
-        apiGatewayRestApiUrl,
-        applicationEndpointUrl,
-        s3BucketName,
-        cloudfrontDistributionId,
-        identityPoolId,
-        userPoolId,
-        userPoolClientId,
-        userPoolClientDomain: `${userPoolDomainName}.auth.${this.region}.amazoncognito.com`,
-      }),
-      description: `Deployment output for the ${stage} environment.`,
-    });
+    // new ssm.StringParameter(this, "DeploymentOutput", {
+    //   parameterName: `/${project}/${stage}/deployment-output`,
+    //   stringValue: JSON.stringify({
+    //     apiGatewayRestApiUrl,
+    //     applicationEndpointUrl,
+    //     s3BucketName,
+    //     cloudfrontDistributionId,
+    //     identityPoolId,
+    //     userPoolId,
+    //     userPoolClientId,
+    //     userPoolClientDomain: `${userPoolDomainName}.auth.${this.region}.amazoncognito.com`,
+    //   }),
+    //   description: `Deployment output for the ${stage} environment.`,
+    // });
 
     new CfnOutput(this, "CloudFrontUrl", {
       value: applicationEndpointUrl,

--- a/deployment/stacks/parent.ts
+++ b/deployment/stacks/parent.ts
@@ -2,7 +2,7 @@ import { Construct } from "constructs";
 import {
   aws_ec2 as ec2,
   aws_iam as iam,
-  // aws_ssm as ssm,
+  aws_ssm as ssm,
   CfnOutput,
   Stack,
   StackProps,
@@ -14,7 +14,7 @@ import { createUiAuthComponents } from "./ui-auth";
 import { createUiComponents } from "./ui";
 import { createApiComponents } from "./api";
 import { sortSubnets } from "../utils/vpc";
-// import { deployFrontend } from "./deployFrontend";
+import { deployFrontend } from "./deployFrontend";
 import { createCustomResourceRole } from "./customResourceRole";
 
 export class ParentStack extends Stack {
@@ -64,9 +64,7 @@ export class ParentStack extends Stack {
       ...commonProps,
       customResourceRole,
     });
-
-    // const { apiGatewayRestApiUrl, restApiId } = createApiComponents({
-      const { restApiId } = createApiComponents({
+    const { apiGatewayRestApiUrl, restApiId } = createApiComponents({
       ...commonProps,
       vpc,
       privateSubnets,
@@ -76,22 +74,21 @@ export class ParentStack extends Stack {
 
     const {
       applicationEndpointUrl,
-      // cloudfrontDistributionId,
-      // distribution,
-      // s3BucketName,
-      // uiBucket,
+      cloudfrontDistributionId,
+      distribution,
+      s3BucketName,
+      uiBucket,
     } = createUiComponents({
       deploymentConfigParameters,
       ...commonProps,
     });
 
-    // const {
-    //   userPoolDomainName,
-    //   identityPoolId,
-    //   userPoolId,
-    //   userPoolClientId,
-    // } =
-    createUiAuthComponents({
+    const {
+      userPoolDomainName,
+      identityPoolId,
+      userPoolId,
+      userPoolClientId,
+    } = createUiAuthComponents({
       ...commonProps,
       oktaMetadataUrl,
       applicationEndpointUrl,
@@ -100,33 +97,33 @@ export class ParentStack extends Stack {
       customResourceRole,
     });
 
-    // deployFrontend({
-    //   ...commonProps,
-    //   uiBucket,
-    //   distribution,
-    //   apiGatewayRestApiUrl,
-    //   applicationEndpointUrl,
-    //   identityPoolId,
-    //   userPoolId,
-    //   userPoolClientId,
-    //   userPoolClientDomain: `${userPoolDomainName}.auth.${this.region}.amazoncognito.com`,
-    //   customResourceRole,
-    // });
+    deployFrontend({
+      ...commonProps,
+      uiBucket,
+      distribution,
+      apiGatewayRestApiUrl,
+      applicationEndpointUrl,
+      identityPoolId,
+      userPoolId,
+      userPoolClientId,
+      userPoolClientDomain: `${userPoolDomainName}.auth.${this.region}.amazoncognito.com`,
+      customResourceRole,
+    });
 
-    // new ssm.StringParameter(this, "DeploymentOutput", {
-    //   parameterName: `/${project}/${stage}/deployment-output`,
-    //   stringValue: JSON.stringify({
-    //     apiGatewayRestApiUrl,
-    //     applicationEndpointUrl,
-    //     s3BucketName,
-    //     cloudfrontDistributionId,
-    //     identityPoolId,
-    //     userPoolId,
-    //     userPoolClientId,
-    //     userPoolClientDomain: `${userPoolDomainName}.auth.${this.region}.amazoncognito.com`,
-    //   }),
-    //   description: `Deployment output for the ${stage} environment.`,
-    // });
+    new ssm.StringParameter(this, "DeploymentOutput", {
+      parameterName: `/${project}/${stage}/deployment-output`,
+      stringValue: JSON.stringify({
+        apiGatewayRestApiUrl,
+        applicationEndpointUrl,
+        s3BucketName,
+        cloudfrontDistributionId,
+        identityPoolId,
+        userPoolId,
+        userPoolClientId,
+        userPoolClientDomain: `${userPoolDomainName}.auth.${this.region}.amazoncognito.com`,
+      }),
+      description: `Deployment output for the ${stage} environment.`,
+    });
 
     new CfnOutput(this, "CloudFrontUrl", {
       value: applicationEndpointUrl,

--- a/deployment/stacks/parent.ts
+++ b/deployment/stacks/parent.ts
@@ -2,7 +2,7 @@ import { Construct } from "constructs";
 import {
   aws_ec2 as ec2,
   aws_iam as iam,
-  // aws_ssm as ssm,
+  aws_ssm as ssm,
   CfnOutput,
   Stack,
   StackProps,
@@ -14,7 +14,7 @@ import { createUiAuthComponents } from "./ui-auth";
 import { createUiComponents } from "./ui";
 import { createApiComponents } from "./api";
 import { sortSubnets } from "../utils/vpc";
-// import { deployFrontend } from "./deployFrontend";
+import { deployFrontend } from "./deployFrontend";
 import { createCustomResourceRole } from "./customResourceRole";
 
 export class ParentStack extends Stack {
@@ -65,8 +65,7 @@ export class ParentStack extends Stack {
       customResourceRole,
     });
 
-    // const { apiGatewayRestApiUrl, restApiId } = createApiComponents({
-      const { restApiId } = createApiComponents({
+    const { apiGatewayRestApiUrl, restApiId } = createApiComponents({
       ...commonProps,
       vpc,
       privateSubnets,
@@ -76,22 +75,21 @@ export class ParentStack extends Stack {
 
     const {
       applicationEndpointUrl,
-      // cloudfrontDistributionId,
-      // distribution,
-      // s3BucketName,
-      // uiBucket,
+      cloudfrontDistributionId,
+      distribution,
+      s3BucketName,
+      uiBucket,
     } = createUiComponents({
       deploymentConfigParameters,
       ...commonProps,
     });
 
-    // const {
-    //   userPoolDomainName,
-    //   identityPoolId,
-    //   userPoolId,
-    //   userPoolClientId,
-    // } =
-    createUiAuthComponents({
+    const {
+      userPoolDomainName,
+      identityPoolId,
+      userPoolId,
+      userPoolClientId,
+    } = createUiAuthComponents({
       ...commonProps,
       oktaMetadataUrl,
       applicationEndpointUrl,
@@ -100,33 +98,33 @@ export class ParentStack extends Stack {
       customResourceRole,
     });
 
-    // deployFrontend({
-    //   ...commonProps,
-    //   uiBucket,
-    //   distribution,
-    //   apiGatewayRestApiUrl,
-    //   applicationEndpointUrl,
-    //   identityPoolId,
-    //   userPoolId,
-    //   userPoolClientId,
-    //   userPoolClientDomain: `${userPoolDomainName}.auth.${this.region}.amazoncognito.com`,
-    //   customResourceRole,
-    // });
+    deployFrontend({
+      ...commonProps,
+      uiBucket,
+      distribution,
+      apiGatewayRestApiUrl,
+      applicationEndpointUrl,
+      identityPoolId,
+      userPoolId,
+      userPoolClientId,
+      userPoolClientDomain: `${userPoolDomainName}.auth.${this.region}.amazoncognito.com`,
+      customResourceRole,
+    });
 
-    // new ssm.StringParameter(this, "DeploymentOutput", {
-    //   parameterName: `/${project}/${stage}/deployment-output`,
-    //   stringValue: JSON.stringify({
-    //     apiGatewayRestApiUrl,
-    //     applicationEndpointUrl,
-    //     s3BucketName,
-    //     cloudfrontDistributionId,
-    //     identityPoolId,
-    //     userPoolId,
-    //     userPoolClientId,
-    //     userPoolClientDomain: `${userPoolDomainName}.auth.${this.region}.amazoncognito.com`,
-    //   }),
-    //   description: `Deployment output for the ${stage} environment.`,
-    // });
+    new ssm.StringParameter(this, "DeploymentOutput", {
+      parameterName: `/${project}/${stage}/deployment-output`,
+      stringValue: JSON.stringify({
+        apiGatewayRestApiUrl,
+        applicationEndpointUrl,
+        s3BucketName,
+        cloudfrontDistributionId,
+        identityPoolId,
+        userPoolId,
+        userPoolClientId,
+        userPoolClientDomain: `${userPoolDomainName}.auth.${this.region}.amazoncognito.com`,
+      }),
+      description: `Deployment output for the ${stage} environment.`,
+    });
 
     new CfnOutput(this, "CloudFrontUrl", {
       value: applicationEndpointUrl,

--- a/deployment/stacks/parent.ts
+++ b/deployment/stacks/parent.ts
@@ -64,6 +64,7 @@ export class ParentStack extends Stack {
       ...commonProps,
       customResourceRole,
     });
+
     const { apiGatewayRestApiUrl, restApiId } = createApiComponents({
       ...commonProps,
       vpc,

--- a/deployment/stacks/ui-auth.ts
+++ b/deployment/stacks/ui-auth.ts
@@ -6,7 +6,6 @@ import {
   aws_lambda_nodejs as lambda_nodejs,
   aws_wafv2 as wafv2,
   aws_ssm as ssm,
-  RemovalPolicy,
   Aws,
   Duration,
   custom_resources as cr,
@@ -40,7 +39,6 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
 
   const userPool = new cognito.UserPool(scope, "UserPool", {
     userPoolName: `${stage}-user-pool`,
-    removalPolicy: RemovalPolicy.RETAIN,
     signInAliases: {
       email: true,
     },

--- a/deployment/stacks/ui-auth.ts
+++ b/deployment/stacks/ui-auth.ts
@@ -2,14 +2,14 @@ import { Construct } from "constructs";
 import {
   aws_cognito as cognito,
   aws_iam as iam,
-  aws_lambda as lambda,
-  aws_lambda_nodejs as lambda_nodejs,
-  aws_wafv2 as wafv2,
-  aws_ssm as ssm,
+  // aws_lambda as lambda,
+  // aws_lambda_nodejs as lambda_nodejs,
+  // aws_wafv2 as wafv2,
+  // aws_ssm as ssm,
   RemovalPolicy,
-  Aws,
-  Duration,
-  custom_resources as cr,
+  // Aws,
+  // Duration,
+  // custom_resources as cr,
 } from "aws-cdk-lib";
 import { WafConstruct } from "../constructs/waf";
 import { IManagedPolicy } from "aws-cdk-lib/aws-iam";
@@ -30,15 +30,16 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
   const {
     scope,
     stage,
-    oktaMetadataUrl,
-    applicationEndpointUrl,
-    restApiId,
+    // oktaMetadataUrl,
+    // applicationEndpointUrl,
+    // restApiId,
     bootstrapUsersPasswordArn,
     iamPath,
     iamPermissionsBoundary,
   } = props;
 
-  const userPool = new cognito.UserPool(scope, "UserPool", {
+  // const userPool =
+  new cognito.UserPool(scope, "UserPool", {
     userPoolName: `${stage}-user-pool`,
     removalPolicy: RemovalPolicy.RETAIN,
     signInAliases: {
@@ -68,138 +69,139 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
     advancedSecurityMode: cognito.AdvancedSecurityMode.ENFORCED,
   });
 
-  let supportedIdentityProviders:
-    | cognito.UserPoolClientIdentityProvider[]
-    | undefined = undefined;
+  // let supportedIdentityProviders:
+  //   | cognito.UserPoolClientIdentityProvider[]
+  //   | undefined = undefined;
 
-  if (oktaMetadataUrl) {
-    const providerName = "Okta";
+  // if (oktaMetadataUrl) {
+  //   const providerName = "Okta";
 
-    new cognito.CfnUserPoolIdentityProvider(
-      scope,
-      "CognitoUserPoolIdentityProvider",
-      {
-        providerName,
-        providerType: "SAML",
-        userPoolId: userPool.userPoolId,
-        providerDetails: {
-          MetadataURL: oktaMetadataUrl,
-        },
-        attributeMapping: {
-          email:
-            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
-          family_name:
-            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
-          given_name:
-            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
-          "custom:ismemberof": "ismemberof",
-        },
-        idpIdentifiers: ["IdpIdentifier"],
-      }
-    );
+    // new cognito.CfnUserPoolIdentityProvider(
+    //   scope,
+    //   "CognitoUserPoolIdentityProvider",
+    //   {
+    //     providerName,
+    //     providerType: "SAML",
+    //     userPoolId: userPool.userPoolId,
+    //     providerDetails: {
+    //       MetadataURL: oktaMetadataUrl,
+    //     },
+    //     attributeMapping: {
+    //       email:
+    //         "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+    //       family_name:
+    //         "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
+    //       given_name:
+    //         "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
+    //       "custom:ismemberof": "ismemberof",
+    //     },
+    //     idpIdentifiers: ["IdpIdentifier"],
+    //   }
+    // );
 
-    supportedIdentityProviders = [
-      cognito.UserPoolClientIdentityProvider.custom(providerName),
-    ];
-  }
+  //   supportedIdentityProviders = [
+  //     cognito.UserPoolClientIdentityProvider.custom(providerName),
+  //   ];
+  // }
 
-  const userPoolClient = new cognito.UserPoolClient(scope, "UserPoolClient", {
-    userPoolClientName: `${stage}-user-pool-client`,
-    userPool,
-    authFlows: {
-      userPassword: true,
-    },
-    oAuth: {
-      flows: {
-        implicitCodeGrant: true,
-      },
-      scopes: [
-        cognito.OAuthScope.EMAIL,
-        cognito.OAuthScope.OPENID,
-        cognito.OAuthScope.PROFILE,
-      ],
-      callbackUrls: [applicationEndpointUrl || "https://localhost:3000/"],
-      defaultRedirectUri: applicationEndpointUrl,
-      logoutUrls: [applicationEndpointUrl || "https://localhost:3000/"],
-    },
-    supportedIdentityProviders,
-    generateSecret: false,
-  });
+  // const userPoolClient = new cognito.UserPoolClient(scope, "UserPoolClient", {
+  //   userPoolClientName: `${stage}-user-pool-client`,
+  //   userPool,
+  //   authFlows: {
+  //     userPassword: true,
+  //   },
+  //   oAuth: {
+  //     flows: {
+  //       implicitCodeGrant: true,
+  //     },
+  //     scopes: [
+  //       cognito.OAuthScope.EMAIL,
+  //       cognito.OAuthScope.OPENID,
+  //       cognito.OAuthScope.PROFILE,
+  //     ],
+  //     callbackUrls: [applicationEndpointUrl || "https://localhost:3000/"],
+  //     defaultRedirectUri: applicationEndpointUrl,
+  //     logoutUrls: [applicationEndpointUrl || "https://localhost:3000/"],
+  //   },
+  //   supportedIdentityProviders,
+  //   generateSecret: false,
+  // });
 
-  (userPoolClient.node
-    .defaultChild as cognito.CfnUserPoolClient).addPropertyOverride(
-    "ExplicitAuthFlows",
-    ["ADMIN_NO_SRP_AUTH", "USER_PASSWORD_AUTH"]
-  );
+  // (userPoolClient.node
+  //   .defaultChild as cognito.CfnUserPoolClient).addPropertyOverride(
+  //   "ExplicitAuthFlows",
+  //   ["ADMIN_NO_SRP_AUTH", "USER_PASSWORD_AUTH"]
+  // );
 
-  const userPoolDomain = new cognito.UserPoolDomain(scope, "UserPoolDomain", {
-    userPool,
-    cognitoDomain: { domainPrefix: `${stage}-login-user-pool-client` },
-  });
+  // const userPoolDomain = new cognito.UserPoolDomain(scope, "UserPoolDomain", {
+  //   userPool,
+  //   cognitoDomain: { domainPrefix: `${stage}-login-user-pool-client` },
+  // });
 
-  const identityPool = new cognito.CfnIdentityPool(
-    scope,
-    "CognitoIdentityPool",
-    {
-      identityPoolName: `${stage}IdentityPool`,
-      allowUnauthenticatedIdentities: false,
-      cognitoIdentityProviders: [
-        {
-          clientId: userPoolClient.userPoolClientId,
-          providerName: userPool.userPoolProviderName,
-        },
-      ],
-    }
-  );
+  // const identityPool = new cognito.CfnIdentityPool(
+  //   scope,
+  //   "CognitoIdentityPool",
+  //   {
+  //     identityPoolName: `${stage}IdentityPool`,
+  //     allowUnauthenticatedIdentities: false,
+  //     cognitoIdentityProviders: [
+  //       {
+  //         clientId: userPoolClient.userPoolClientId,
+  //         providerName: userPool.userPoolProviderName,
+  //       },
+  //     ],
+  //   }
+  // );
 
-  const cognitoAuthRole = new iam.Role(scope, "CognitoAuthRole", {
-    permissionsBoundary: iamPermissionsBoundary,
-    path: iamPath,
-    assumedBy: new iam.FederatedPrincipal(
-      "cognito-identity.amazonaws.com",
-      {
-        StringEquals: {
-          "cognito-identity.amazonaws.com:aud": identityPool.ref,
-        },
-        "ForAnyValue:StringLike": {
-          "cognito-identity.amazonaws.com:amr": "authenticated",
-        },
-      },
-      "sts:AssumeRoleWithWebIdentity"
-    ),
-    inlinePolicies: {
-      CognitoAuthorizedPolicy: new iam.PolicyDocument({
-        statements: [
-          new iam.PolicyStatement({
-            actions: [
-              "mobileanalytics:PutEvents",
-              "cognito-sync:*",
-              "cognito-identity:*",
-            ],
-            resources: ["*"],
-            effect: iam.Effect.ALLOW,
-          }),
-          new iam.PolicyStatement({
-            actions: ["execute-api:Invoke"],
-            resources: [
-              `arn:aws:execute-api:${Aws.REGION}:${Aws.ACCOUNT_ID}:${restApiId}/*`,
-            ],
-            effect: iam.Effect.ALLOW,
-          }),
-        ],
-      }),
-    },
-  });
+  // const cognitoAuthRole = new iam.Role(scope, "CognitoAuthRole", {
+  //   permissionsBoundary: iamPermissionsBoundary,
+  //   path: iamPath,
+  //   assumedBy: new iam.FederatedPrincipal(
+  //     "cognito-identity.amazonaws.com",
+  //     {
+  //       StringEquals: {
+  //         "cognito-identity.amazonaws.com:aud": identityPool.ref,
+  //       },
+  //       "ForAnyValue:StringLike": {
+  //         "cognito-identity.amazonaws.com:amr": "authenticated",
+  //       },
+  //     },
+  //     "sts:AssumeRoleWithWebIdentity"
+  //   ),
+  //   inlinePolicies: {
+  //     CognitoAuthorizedPolicy: new iam.PolicyDocument({
+  //       statements: [
+  //         new iam.PolicyStatement({
+  //           actions: [
+  //             "mobileanalytics:PutEvents",
+  //             "cognito-sync:*",
+  //             "cognito-identity:*",
+  //           ],
+  //           resources: ["*"],
+  //           effect: iam.Effect.ALLOW,
+  //         }),
+  //         new iam.PolicyStatement({
+  //           actions: ["execute-api:Invoke"],
+  //           resources: [
+  //             `arn:aws:execute-api:${Aws.REGION}:${Aws.ACCOUNT_ID}:${restApiId}/*`,
+  //           ],
+  //           effect: iam.Effect.ALLOW,
+  //         }),
+  //       ],
+  //     }),
+  //   },
+  // });
 
-  new cognito.CfnIdentityPoolRoleAttachment(scope, "CognitoIdentityPoolRoles", {
-    identityPoolId: identityPool.ref,
-    roles: { authenticated: cognitoAuthRole.roleArn },
-  });
+  // new cognito.CfnIdentityPoolRoleAttachment(scope, "CognitoIdentityPoolRoles", {
+  //   identityPoolId: identityPool.ref,
+  //   roles: { authenticated: cognitoAuthRole.roleArn },
+  // });
 
-  let bootstrapUsersFunction;
+  // let bootstrapUsersFunction;
 
   if (bootstrapUsersPasswordArn) {
-    const lambdaApiRole = new iam.Role(scope, "BootstrapUsersLambdaApiRole", {
+    // const lambdaApiRole =
+    new iam.Role(scope, "BootstrapUsersLambdaApiRole", {
       permissionsBoundary: iamPermissionsBoundary,
       path: iamPath,
       assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
@@ -220,11 +222,11 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
               resources: ["arn:aws:logs:*:*:*"],
               effect: iam.Effect.ALLOW,
             }),
-            new iam.PolicyStatement({
-              actions: ["*"],
-              resources: [userPool.userPoolArn],
-              effect: iam.Effect.ALLOW,
-            }),
+            // new iam.PolicyStatement({
+            //   actions: ["*"],
+            //   resources: [userPool.userPoolArn],
+            //   effect: iam.Effect.ALLOW,
+            // }),
             new iam.PolicyStatement({
               actions: ["ssm:GetParameter"],
               resources: [bootstrapUsersPasswordArn],
@@ -234,83 +236,84 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
         }),
       },
     });
-
-    // TODO: test deploy and watch performance with scope using lambda.Function vs lambda_nodejs.NodejsFunction
-    bootstrapUsersFunction = new lambda_nodejs.NodejsFunction(
-      scope,
-      "bootstrapUsers",
-      {
-        entry: "services/ui-auth/handlers/createUsers.js",
-        handler: "handler",
-        runtime: lambda.Runtime.NODEJS_20_X,
-        timeout: Duration.seconds(60),
-        role: lambdaApiRole,
-        environment: {
-          userPoolId: userPool.userPoolId,
-          bootstrapUsersPasswordArn: bootstrapUsersPasswordArn,
-        },
-      }
-    );
   }
+    // TODO: test deploy and watch performance with scope using lambda.Function vs lambda_nodejs.NodejsFunction
+  //   bootstrapUsersFunction = new lambda_nodejs.NodejsFunction(
+  //     scope,
+  //     "bootstrapUsers",
+  //     {
+  //       entry: "services/ui-auth/handlers/createUsers.js",
+  //       handler: "handler",
+  //       runtime: lambda.Runtime.NODEJS_20_X,
+  //       timeout: Duration.seconds(60),
+  //       role: lambdaApiRole,
+  //       environment: {
+  //         userPoolId: userPool.userPoolId,
+  //         bootstrapUsersPasswordArn: bootstrapUsersPasswordArn,
+  //       },
+  //     }
+  //   );
+  // }
 
-  const webAcl = new WafConstruct(
+  // const webAcl =
+  new WafConstruct(
     scope,
     "CognitoWafConstruct",
     { name: `ui-auth-${stage}-webacl-waf` },
     "REGIONAL"
   ).webAcl;
 
-  new wafv2.CfnWebACLAssociation(scope, "CognitoUserPoolWAFAssociation", {
-    resourceArn: userPool.userPoolArn,
-    webAclArn: webAcl.attrArn,
-  });
+  // new wafv2.CfnWebACLAssociation(scope, "CognitoUserPoolWAFAssociation", {
+  //   resourceArn: userPool.userPoolArn,
+  //   webAclArn: webAcl.attrArn,
+  // });
 
-  new ssm.StringParameter(scope, "CognitoUserPoolIdParameter", {
-    parameterName: `/${stage}/ui-auth/cognito_user_pool_id`,
-    stringValue: userPool.userPoolId,
-  });
-  new ssm.StringParameter(scope, "CognitoUserPoolClientIdParameter", {
-    parameterName: `/${stage}/ui-auth/cognito_user_pool_client_id`,
-    stringValue: userPoolClient.userPoolClientId,
-  });
+  // new ssm.StringParameter(scope, "CognitoUserPoolIdParameter", {
+  //   parameterName: `/${stage}/ui-auth/cognito_user_pool_id`,
+  //   stringValue: userPool.userPoolId,
+  // });
+  // new ssm.StringParameter(scope, "CognitoUserPoolClientIdParameter", {
+  //   parameterName: `/${stage}/ui-auth/cognito_user_pool_client_id`,
+  //   stringValue: userPoolClient.userPoolClientId,
+  // });
 
-  if (bootstrapUsersFunction) {
-    const bootstrapUsersInvoke = new cr.AwsCustomResource(
-      scope,
-      "InvokeBootstrapUsersFunction",
-      {
-        onCreate: {
-          service: "Lambda",
-          action: "invoke",
-          parameters: {
-            FunctionName: bootstrapUsersFunction.functionName,
-            InvocationType: "Event",
-            Payload: JSON.stringify({}),
-          },
-          physicalResourceId: cr.PhysicalResourceId.of(
-            `InvokeBootstrapUsersFunction-${stage}`
-          ),
-        },
-        onUpdate: undefined,
-        onDelete: undefined,
-        policy: cr.AwsCustomResourcePolicy.fromStatements([
-          new iam.PolicyStatement({
-            actions: ["lambda:InvokeFunction"],
-            resources: [bootstrapUsersFunction.functionArn],
-          }),
-        ]),
-        role: props.customResourceRole,
-        resourceType: "Custom::InvokeBootstrapUsersFunction",
-      }
-    );
+  // if (bootstrapUsersFunction) {
+  //   const bootstrapUsersInvoke = new cr.AwsCustomResource(
+  //     scope,
+  //     "InvokeBootstrapUsersFunction",
+  //     {
+  //       onCreate: {
+  //         service: "Lambda",
+  //         action: "invoke",
+  //         parameters: {
+  //           FunctionName: bootstrapUsersFunction.functionName,
+  //           InvocationType: "Event",
+  //           Payload: JSON.stringify({}),
+  //         },
+  //         physicalResourceId: cr.PhysicalResourceId.of(
+  //           `InvokeBootstrapUsersFunction-${stage}`
+  //         ),
+  //       },
+  //       onUpdate: undefined,
+  //       onDelete: undefined,
+  //       policy: cr.AwsCustomResourcePolicy.fromStatements([
+  //         new iam.PolicyStatement({
+  //           actions: ["lambda:InvokeFunction"],
+  //           resources: [bootstrapUsersFunction.functionArn],
+  //         }),
+  //       ]),
+  //       role: props.customResourceRole,
+  //       resourceType: "Custom::InvokeBootstrapUsersFunction",
+  //     }
+  //   );
 
-    bootstrapUsersInvoke.node.addDependency(bootstrapUsersFunction);
-  }
+  //   bootstrapUsersInvoke.node.addDependency(bootstrapUsersFunction);
+  // }
 
   return {
-    userPoolDomainName: userPoolDomain.domainName,
-    identityPoolId: identityPool.ref,
-    userPoolId: userPool.userPoolId,
-    userPoolClientId: userPoolClient.userPoolClientId,
+    // userPoolDomainName: userPoolDomain.domainName,
+    // identityPoolId: identityPool.ref,
+    // userPoolId: userPool.userPoolId,
+    // userPoolClientId: userPoolClient.userPoolClientId,
   };
 }

--- a/deployment/stacks/ui-auth.ts
+++ b/deployment/stacks/ui-auth.ts
@@ -208,35 +208,32 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
           "service-role/AWSLambdaVPCAccessExecutionRole"
         ),
       ],
+      inlinePolicies: {
+        LambdaApiRolePolicy: new iam.PolicyDocument({
+          statements: [
+            new iam.PolicyStatement({
+              actions: [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              resources: ["arn:aws:logs:*:*:*"],
+              effect: iam.Effect.ALLOW,
+            }),
+            new iam.PolicyStatement({
+              actions: ["*"],
+              resources: [userPool.userPoolArn],
+              effect: iam.Effect.ALLOW,
+            }),
+            new iam.PolicyStatement({
+              actions: ["ssm:GetParameter"],
+              resources: [bootstrapUsersPasswordArn],
+              effect: iam.Effect.ALLOW,
+            }),
+          ],
+        }),
+      },
     });
-
-    lambdaApiRole.addToPolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: [
-          "logs:CreateLogGroup",
-          "logs:CreateLogStream",
-          "logs:PutLogEvents",
-        ],
-        resources: ["arn:aws:logs:*:*:*"],
-      })
-    );
-
-    lambdaApiRole.addToPolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ["*"],
-        resources: [userPool.userPoolArn],
-      })
-    );
-
-    lambdaApiRole.addToPolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ["ssm:GetParameter"],
-        resources: [bootstrapUsersPasswordArn],
-      })
-    );
 
     // TODO: test deploy and watch performance with scope using lambda.Function vs lambda_nodejs.NodejsFunction
     bootstrapUsersFunction = new lambda_nodejs.NodejsFunction(

--- a/deployment/stacks/ui-auth.ts
+++ b/deployment/stacks/ui-auth.ts
@@ -1,12 +1,12 @@
 import { Construct } from "constructs";
 import {
-  // aws_cognito as cognito,
+  aws_cognito as cognito,
   aws_iam as iam,
   // aws_lambda as lambda,
   // aws_lambda_nodejs as lambda_nodejs,
   // aws_wafv2 as wafv2,
   // aws_ssm as ssm,
-  // RemovalPolicy,
+  RemovalPolicy,
   // Aws,
   // Duration,
   // custom_resources as cr,
@@ -38,35 +38,36 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
     iamPermissionsBoundary,
   } = props;
 
-  // const userPool = new cognito.UserPool(scope, "UserPool", {
-  //   userPoolName: `${stage}-user-pool`,
-  //   removalPolicy: RemovalPolicy.DESTROY,
-  //   signInAliases: {
-  //     email: true,
-  //   },
-  //   autoVerify: {
-  //     email: true,
-  //   },
-  //   selfSignUpEnabled: false,
-  //   standardAttributes: {
-  //     givenName: {
-  //       required: false,
-  //       mutable: true,
-  //     },
-  //     familyName: {
-  //       required: false,
-  //       mutable: true,
-  //     },
-  //     phoneNumber: {
-  //       required: false,
-  //       mutable: true,
-  //     },
-  //   },
-  //   customAttributes: {
-  //     ismemberof: new cognito.StringAttribute({ mutable: true }),
-  //   },
-  //   advancedSecurityMode: cognito.AdvancedSecurityMode.ENFORCED,
-  // });
+  // const userPool =
+  new cognito.UserPool(scope, "UserPool", {
+    userPoolName: `${stage}-user-pool`,
+    removalPolicy: RemovalPolicy.RETAIN,
+    signInAliases: {
+      email: true,
+    },
+    autoVerify: {
+      email: true,
+    },
+    selfSignUpEnabled: false,
+    standardAttributes: {
+      givenName: {
+        required: false,
+        mutable: true,
+      },
+      familyName: {
+        required: false,
+        mutable: true,
+      },
+      phoneNumber: {
+        required: false,
+        mutable: true,
+      },
+    },
+    customAttributes: {
+      ismemberof: new cognito.StringAttribute({ mutable: true }),
+    },
+    advancedSecurityMode: cognito.AdvancedSecurityMode.ENFORCED,
+  });
 
   // let supportedIdentityProviders:
   //   | cognito.UserPoolClientIdentityProvider[]

--- a/deployment/stacks/ui-auth.ts
+++ b/deployment/stacks/ui-auth.ts
@@ -2,14 +2,14 @@ import { Construct } from "constructs";
 import {
   aws_cognito as cognito,
   aws_iam as iam,
-  // aws_lambda as lambda,
-  // aws_lambda_nodejs as lambda_nodejs,
-  // aws_wafv2 as wafv2,
-  // aws_ssm as ssm,
+  aws_lambda as lambda,
+  aws_lambda_nodejs as lambda_nodejs,
+  aws_wafv2 as wafv2,
+  aws_ssm as ssm,
   RemovalPolicy,
-  // Aws,
-  // Duration,
-  // custom_resources as cr,
+  Aws,
+  Duration,
+  custom_resources as cr,
 } from "aws-cdk-lib";
 import { WafConstruct } from "../constructs/waf";
 import { IManagedPolicy } from "aws-cdk-lib/aws-iam";
@@ -30,16 +30,15 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
   const {
     scope,
     stage,
-    // oktaMetadataUrl,
-    // applicationEndpointUrl,
-    // restApiId,
+    oktaMetadataUrl,
+    applicationEndpointUrl,
+    restApiId,
     bootstrapUsersPasswordArn,
     iamPath,
     iamPermissionsBoundary,
   } = props;
 
-  // const userPool =
-  new cognito.UserPool(scope, "UserPool", {
+  const userPool = new cognito.UserPool(scope, "UserPool", {
     userPoolName: `${stage}-user-pool`,
     removalPolicy: RemovalPolicy.RETAIN,
     signInAliases: {
@@ -69,139 +68,138 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
     advancedSecurityMode: cognito.AdvancedSecurityMode.ENFORCED,
   });
 
-  // let supportedIdentityProviders:
-  //   | cognito.UserPoolClientIdentityProvider[]
-  //   | undefined = undefined;
+  let supportedIdentityProviders:
+    | cognito.UserPoolClientIdentityProvider[]
+    | undefined = undefined;
 
-  // if (oktaMetadataUrl) {
-  //   const providerName = "Okta";
+  if (oktaMetadataUrl) {
+    const providerName = "Okta";
 
-    // new cognito.CfnUserPoolIdentityProvider(
-    //   scope,
-    //   "CognitoUserPoolIdentityProvider",
-    //   {
-    //     providerName,
-    //     providerType: "SAML",
-    //     userPoolId: userPool.userPoolId,
-    //     providerDetails: {
-    //       MetadataURL: oktaMetadataUrl,
-    //     },
-    //     attributeMapping: {
-    //       email:
-    //         "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
-    //       family_name:
-    //         "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
-    //       given_name:
-    //         "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
-    //       "custom:ismemberof": "ismemberof",
-    //     },
-    //     idpIdentifiers: ["IdpIdentifier"],
-    //   }
-    // );
+    new cognito.CfnUserPoolIdentityProvider(
+      scope,
+      "CognitoUserPoolIdentityProvider",
+      {
+        providerName,
+        providerType: "SAML",
+        userPoolId: userPool.userPoolId,
+        providerDetails: {
+          MetadataURL: oktaMetadataUrl,
+        },
+        attributeMapping: {
+          email:
+            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+          family_name:
+            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
+          given_name:
+            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
+          "custom:ismemberof": "ismemberof",
+        },
+        idpIdentifiers: ["IdpIdentifier"],
+      }
+    );
 
-  //   supportedIdentityProviders = [
-  //     cognito.UserPoolClientIdentityProvider.custom(providerName),
-  //   ];
-  // }
+    supportedIdentityProviders = [
+      cognito.UserPoolClientIdentityProvider.custom(providerName),
+    ];
+  }
 
-  // const userPoolClient = new cognito.UserPoolClient(scope, "UserPoolClient", {
-  //   userPoolClientName: `${stage}-user-pool-client`,
-  //   userPool,
-  //   authFlows: {
-  //     userPassword: true,
-  //   },
-  //   oAuth: {
-  //     flows: {
-  //       implicitCodeGrant: true,
-  //     },
-  //     scopes: [
-  //       cognito.OAuthScope.EMAIL,
-  //       cognito.OAuthScope.OPENID,
-  //       cognito.OAuthScope.PROFILE,
-  //     ],
-  //     callbackUrls: [applicationEndpointUrl || "https://localhost:3000/"],
-  //     defaultRedirectUri: applicationEndpointUrl,
-  //     logoutUrls: [applicationEndpointUrl || "https://localhost:3000/"],
-  //   },
-  //   supportedIdentityProviders,
-  //   generateSecret: false,
-  // });
+  const userPoolClient = new cognito.UserPoolClient(scope, "UserPoolClient", {
+    userPoolClientName: `${stage}-user-pool-client`,
+    userPool,
+    authFlows: {
+      userPassword: true,
+    },
+    oAuth: {
+      flows: {
+        implicitCodeGrant: true,
+      },
+      scopes: [
+        cognito.OAuthScope.EMAIL,
+        cognito.OAuthScope.OPENID,
+        cognito.OAuthScope.PROFILE,
+      ],
+      callbackUrls: [applicationEndpointUrl || "https://localhost:3000/"],
+      defaultRedirectUri: applicationEndpointUrl,
+      logoutUrls: [applicationEndpointUrl || "https://localhost:3000/"],
+    },
+    supportedIdentityProviders,
+    generateSecret: false,
+  });
 
-  // (userPoolClient.node
-  //   .defaultChild as cognito.CfnUserPoolClient).addPropertyOverride(
-  //   "ExplicitAuthFlows",
-  //   ["ADMIN_NO_SRP_AUTH", "USER_PASSWORD_AUTH"]
-  // );
+  (userPoolClient.node
+    .defaultChild as cognito.CfnUserPoolClient).addPropertyOverride(
+    "ExplicitAuthFlows",
+    ["ADMIN_NO_SRP_AUTH", "USER_PASSWORD_AUTH"]
+  );
 
-  // const userPoolDomain = new cognito.UserPoolDomain(scope, "UserPoolDomain", {
-  //   userPool,
-  //   cognitoDomain: { domainPrefix: `${stage}-login-user-pool-client` },
-  // });
+  const userPoolDomain = new cognito.UserPoolDomain(scope, "UserPoolDomain", {
+    userPool,
+    cognitoDomain: { domainPrefix: `${stage}-login-user-pool-client` },
+  });
 
-  // const identityPool = new cognito.CfnIdentityPool(
-  //   scope,
-  //   "CognitoIdentityPool",
-  //   {
-  //     identityPoolName: `${stage}IdentityPool`,
-  //     allowUnauthenticatedIdentities: false,
-  //     cognitoIdentityProviders: [
-  //       {
-  //         clientId: userPoolClient.userPoolClientId,
-  //         providerName: userPool.userPoolProviderName,
-  //       },
-  //     ],
-  //   }
-  // );
+  const identityPool = new cognito.CfnIdentityPool(
+    scope,
+    "CognitoIdentityPool",
+    {
+      identityPoolName: `${stage}IdentityPool`,
+      allowUnauthenticatedIdentities: false,
+      cognitoIdentityProviders: [
+        {
+          clientId: userPoolClient.userPoolClientId,
+          providerName: userPool.userPoolProviderName,
+        },
+      ],
+    }
+  );
 
-  // const cognitoAuthRole = new iam.Role(scope, "CognitoAuthRole", {
-  //   permissionsBoundary: iamPermissionsBoundary,
-  //   path: iamPath,
-  //   assumedBy: new iam.FederatedPrincipal(
-  //     "cognito-identity.amazonaws.com",
-  //     {
-  //       StringEquals: {
-  //         "cognito-identity.amazonaws.com:aud": identityPool.ref,
-  //       },
-  //       "ForAnyValue:StringLike": {
-  //         "cognito-identity.amazonaws.com:amr": "authenticated",
-  //       },
-  //     },
-  //     "sts:AssumeRoleWithWebIdentity"
-  //   ),
-  //   inlinePolicies: {
-  //     CognitoAuthorizedPolicy: new iam.PolicyDocument({
-  //       statements: [
-  //         new iam.PolicyStatement({
-  //           actions: [
-  //             "mobileanalytics:PutEvents",
-  //             "cognito-sync:*",
-  //             "cognito-identity:*",
-  //           ],
-  //           resources: ["*"],
-  //           effect: iam.Effect.ALLOW,
-  //         }),
-  //         new iam.PolicyStatement({
-  //           actions: ["execute-api:Invoke"],
-  //           resources: [
-  //             `arn:aws:execute-api:${Aws.REGION}:${Aws.ACCOUNT_ID}:${restApiId}/*`,
-  //           ],
-  //           effect: iam.Effect.ALLOW,
-  //         }),
-  //       ],
-  //     }),
-  //   },
-  // });
+  const cognitoAuthRole = new iam.Role(scope, "CognitoAuthRole", {
+    permissionsBoundary: iamPermissionsBoundary,
+    path: iamPath,
+    assumedBy: new iam.FederatedPrincipal(
+      "cognito-identity.amazonaws.com",
+      {
+        StringEquals: {
+          "cognito-identity.amazonaws.com:aud": identityPool.ref,
+        },
+        "ForAnyValue:StringLike": {
+          "cognito-identity.amazonaws.com:amr": "authenticated",
+        },
+      },
+      "sts:AssumeRoleWithWebIdentity"
+    ),
+    inlinePolicies: {
+      CognitoAuthorizedPolicy: new iam.PolicyDocument({
+        statements: [
+          new iam.PolicyStatement({
+            actions: [
+              "mobileanalytics:PutEvents",
+              "cognito-sync:*",
+              "cognito-identity:*",
+            ],
+            resources: ["*"],
+            effect: iam.Effect.ALLOW,
+          }),
+          new iam.PolicyStatement({
+            actions: ["execute-api:Invoke"],
+            resources: [
+              `arn:aws:execute-api:${Aws.REGION}:${Aws.ACCOUNT_ID}:${restApiId}/*`,
+            ],
+            effect: iam.Effect.ALLOW,
+          }),
+        ],
+      }),
+    },
+  });
 
-  // new cognito.CfnIdentityPoolRoleAttachment(scope, "CognitoIdentityPoolRoles", {
-  //   identityPoolId: identityPool.ref,
-  //   roles: { authenticated: cognitoAuthRole.roleArn },
-  // });
+  new cognito.CfnIdentityPoolRoleAttachment(scope, "CognitoIdentityPoolRoles", {
+    identityPoolId: identityPool.ref,
+    roles: { authenticated: cognitoAuthRole.roleArn },
+  });
 
-  // let bootstrapUsersFunction;
+  let bootstrapUsersFunction;
 
   if (bootstrapUsersPasswordArn) {
-    // const lambdaApiRole =
-    new iam.Role(scope, "BootstrapUsersLambdaApiRole", {
+    const lambdaApiRole = new iam.Role(scope, "BootstrapUsersLambdaApiRole", {
       permissionsBoundary: iamPermissionsBoundary,
       path: iamPath,
       assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
@@ -222,11 +220,11 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
               resources: ["arn:aws:logs:*:*:*"],
               effect: iam.Effect.ALLOW,
             }),
-            // new iam.PolicyStatement({
-            //   actions: ["*"],
-            //   resources: [userPool.userPoolArn],
-            //   effect: iam.Effect.ALLOW,
-            // }),
+            new iam.PolicyStatement({
+              actions: ["*"],
+              resources: [userPool.userPoolArn],
+              effect: iam.Effect.ALLOW,
+            }),
             new iam.PolicyStatement({
               actions: ["ssm:GetParameter"],
               resources: [bootstrapUsersPasswordArn],
@@ -236,84 +234,83 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
         }),
       },
     });
-  }
-    // TODO: test deploy and watch performance with scope using lambda.Function vs lambda_nodejs.NodejsFunction
-  //   bootstrapUsersFunction = new lambda_nodejs.NodejsFunction(
-  //     scope,
-  //     "bootstrapUsers",
-  //     {
-  //       entry: "services/ui-auth/handlers/createUsers.js",
-  //       handler: "handler",
-  //       runtime: lambda.Runtime.NODEJS_20_X,
-  //       timeout: Duration.seconds(60),
-  //       role: lambdaApiRole,
-  //       environment: {
-  //         userPoolId: userPool.userPoolId,
-  //         bootstrapUsersPasswordArn: bootstrapUsersPasswordArn,
-  //       },
-  //     }
-  //   );
-  // }
 
-  // const webAcl =
-  new WafConstruct(
+    // TODO: test deploy and watch performance with scope using lambda.Function vs lambda_nodejs.NodejsFunction
+    bootstrapUsersFunction = new lambda_nodejs.NodejsFunction(
+      scope,
+      "bootstrapUsers",
+      {
+        entry: "services/ui-auth/handlers/createUsers.js",
+        handler: "handler",
+        runtime: lambda.Runtime.NODEJS_20_X,
+        timeout: Duration.seconds(60),
+        role: lambdaApiRole,
+        environment: {
+          userPoolId: userPool.userPoolId,
+          bootstrapUsersPasswordArn: bootstrapUsersPasswordArn,
+        },
+      }
+    );
+  }
+
+  const webAcl = new WafConstruct(
     scope,
     "CognitoWafConstruct",
     { name: `ui-auth-${stage}-webacl-waf` },
     "REGIONAL"
   ).webAcl;
 
-  // new wafv2.CfnWebACLAssociation(scope, "CognitoUserPoolWAFAssociation", {
-  //   resourceArn: userPool.userPoolArn,
-  //   webAclArn: webAcl.attrArn,
-  // });
+  new wafv2.CfnWebACLAssociation(scope, "CognitoUserPoolWAFAssociation", {
+    resourceArn: userPool.userPoolArn,
+    webAclArn: webAcl.attrArn,
+  });
 
-  // new ssm.StringParameter(scope, "CognitoUserPoolIdParameter", {
-  //   parameterName: `/${stage}/ui-auth/cognito_user_pool_id`,
-  //   stringValue: userPool.userPoolId,
-  // });
-  // new ssm.StringParameter(scope, "CognitoUserPoolClientIdParameter", {
-  //   parameterName: `/${stage}/ui-auth/cognito_user_pool_client_id`,
-  //   stringValue: userPoolClient.userPoolClientId,
-  // });
+  new ssm.StringParameter(scope, "CognitoUserPoolIdParameter", {
+    parameterName: `/${stage}/ui-auth/cognito_user_pool_id`,
+    stringValue: userPool.userPoolId,
+  });
+  new ssm.StringParameter(scope, "CognitoUserPoolClientIdParameter", {
+    parameterName: `/${stage}/ui-auth/cognito_user_pool_client_id`,
+    stringValue: userPoolClient.userPoolClientId,
+  });
 
-  // if (bootstrapUsersFunction) {
-  //   const bootstrapUsersInvoke = new cr.AwsCustomResource(
-  //     scope,
-  //     "InvokeBootstrapUsersFunction",
-  //     {
-  //       onCreate: {
-  //         service: "Lambda",
-  //         action: "invoke",
-  //         parameters: {
-  //           FunctionName: bootstrapUsersFunction.functionName,
-  //           InvocationType: "Event",
-  //           Payload: JSON.stringify({}),
-  //         },
-  //         physicalResourceId: cr.PhysicalResourceId.of(
-  //           `InvokeBootstrapUsersFunction-${stage}`
-  //         ),
-  //       },
-  //       onUpdate: undefined,
-  //       onDelete: undefined,
-  //       policy: cr.AwsCustomResourcePolicy.fromStatements([
-  //         new iam.PolicyStatement({
-  //           actions: ["lambda:InvokeFunction"],
-  //           resources: [bootstrapUsersFunction.functionArn],
-  //         }),
-  //       ]),
-  //       role: props.customResourceRole,
-  //       resourceType: "Custom::InvokeBootstrapUsersFunction",
-  //     }
-  //   );
+  if (bootstrapUsersFunction) {
+    const bootstrapUsersInvoke = new cr.AwsCustomResource(
+      scope,
+      "InvokeBootstrapUsersFunction",
+      {
+        onCreate: {
+          service: "Lambda",
+          action: "invoke",
+          parameters: {
+            FunctionName: bootstrapUsersFunction.functionName,
+            InvocationType: "Event",
+            Payload: JSON.stringify({}),
+          },
+          physicalResourceId: cr.PhysicalResourceId.of(
+            `InvokeBootstrapUsersFunction-${stage}`
+          ),
+        },
+        onUpdate: undefined,
+        onDelete: undefined,
+        policy: cr.AwsCustomResourcePolicy.fromStatements([
+          new iam.PolicyStatement({
+            actions: ["lambda:InvokeFunction"],
+            resources: [bootstrapUsersFunction.functionArn],
+          }),
+        ]),
+        role: props.customResourceRole,
+        resourceType: "Custom::InvokeBootstrapUsersFunction",
+      }
+    );
 
-  //   bootstrapUsersInvoke.node.addDependency(bootstrapUsersFunction);
-  // }
+    bootstrapUsersInvoke.node.addDependency(bootstrapUsersFunction);
+  }
 
   return {
-    // userPoolDomainName: userPoolDomain.domainName,
-    // identityPoolId: identityPool.ref,
-    // userPoolId: userPool.userPoolId,
-    // userPoolClientId: userPoolClient.userPoolClientId,
+    userPoolDomainName: userPoolDomain.domainName,
+    identityPoolId: identityPool.ref,
+    userPoolId: userPool.userPoolId,
+    userPoolClientId: userPoolClient.userPoolClientId,
   };
 }

--- a/deployment/stacks/ui-auth.ts
+++ b/deployment/stacks/ui-auth.ts
@@ -1,15 +1,15 @@
 import { Construct } from "constructs";
 import {
-  aws_cognito as cognito,
+  // aws_cognito as cognito,
   aws_iam as iam,
-  aws_lambda as lambda,
-  aws_lambda_nodejs as lambda_nodejs,
-  aws_wafv2 as wafv2,
-  aws_ssm as ssm,
-  RemovalPolicy,
-  Aws,
-  Duration,
-  custom_resources as cr,
+  // aws_lambda as lambda,
+  // aws_lambda_nodejs as lambda_nodejs,
+  // aws_wafv2 as wafv2,
+  // aws_ssm as ssm,
+  // RemovalPolicy,
+  // Aws,
+  // Duration,
+  // custom_resources as cr,
 } from "aws-cdk-lib";
 import { WafConstruct } from "../constructs/waf";
 import { IManagedPolicy } from "aws-cdk-lib/aws-iam";
@@ -30,176 +30,177 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
   const {
     scope,
     stage,
-    oktaMetadataUrl,
-    applicationEndpointUrl,
-    restApiId,
+    // oktaMetadataUrl,
+    // applicationEndpointUrl,
+    // restApiId,
     bootstrapUsersPasswordArn,
     iamPath,
     iamPermissionsBoundary,
   } = props;
 
-  const userPool = new cognito.UserPool(scope, "UserPool", {
-    userPoolName: `${stage}-user-pool`,
-    removalPolicy: RemovalPolicy.DESTROY,
-    signInAliases: {
-      email: true,
-    },
-    autoVerify: {
-      email: true,
-    },
-    selfSignUpEnabled: false,
-    standardAttributes: {
-      givenName: {
-        required: false,
-        mutable: true,
-      },
-      familyName: {
-        required: false,
-        mutable: true,
-      },
-      phoneNumber: {
-        required: false,
-        mutable: true,
-      },
-    },
-    customAttributes: {
-      ismemberof: new cognito.StringAttribute({ mutable: true }),
-    },
-    advancedSecurityMode: cognito.AdvancedSecurityMode.ENFORCED,
-  });
+  // const userPool = new cognito.UserPool(scope, "UserPool", {
+  //   userPoolName: `${stage}-user-pool`,
+  //   removalPolicy: RemovalPolicy.DESTROY,
+  //   signInAliases: {
+  //     email: true,
+  //   },
+  //   autoVerify: {
+  //     email: true,
+  //   },
+  //   selfSignUpEnabled: false,
+  //   standardAttributes: {
+  //     givenName: {
+  //       required: false,
+  //       mutable: true,
+  //     },
+  //     familyName: {
+  //       required: false,
+  //       mutable: true,
+  //     },
+  //     phoneNumber: {
+  //       required: false,
+  //       mutable: true,
+  //     },
+  //   },
+  //   customAttributes: {
+  //     ismemberof: new cognito.StringAttribute({ mutable: true }),
+  //   },
+  //   advancedSecurityMode: cognito.AdvancedSecurityMode.ENFORCED,
+  // });
 
-  let supportedIdentityProviders:
-    | cognito.UserPoolClientIdentityProvider[]
-    | undefined = undefined;
+  // let supportedIdentityProviders:
+  //   | cognito.UserPoolClientIdentityProvider[]
+  //   | undefined = undefined;
 
-  if (oktaMetadataUrl) {
-    const providerName = "Okta";
+  // if (oktaMetadataUrl) {
+  //   const providerName = "Okta";
 
-    new cognito.CfnUserPoolIdentityProvider(
-      scope,
-      "CognitoUserPoolIdentityProvider",
-      {
-        providerName,
-        providerType: "SAML",
-        userPoolId: userPool.userPoolId,
-        providerDetails: {
-          MetadataURL: oktaMetadataUrl,
-        },
-        attributeMapping: {
-          email:
-            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
-          family_name:
-            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
-          given_name:
-            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
-          "custom:ismemberof": "ismemberof",
-        },
-        idpIdentifiers: ["IdpIdentifier"],
-      }
-    );
+    // new cognito.CfnUserPoolIdentityProvider(
+    //   scope,
+    //   "CognitoUserPoolIdentityProvider",
+    //   {
+    //     providerName,
+    //     providerType: "SAML",
+    //     userPoolId: userPool.userPoolId,
+    //     providerDetails: {
+    //       MetadataURL: oktaMetadataUrl,
+    //     },
+    //     attributeMapping: {
+    //       email:
+    //         "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+    //       family_name:
+    //         "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
+    //       given_name:
+    //         "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
+    //       "custom:ismemberof": "ismemberof",
+    //     },
+    //     idpIdentifiers: ["IdpIdentifier"],
+    //   }
+    // );
 
-    supportedIdentityProviders = [
-      cognito.UserPoolClientIdentityProvider.custom(providerName),
-    ];
-  }
+  //   supportedIdentityProviders = [
+  //     cognito.UserPoolClientIdentityProvider.custom(providerName),
+  //   ];
+  // }
 
-  const userPoolClient = new cognito.UserPoolClient(scope, "UserPoolClient", {
-    userPoolClientName: `${stage}-user-pool-client`,
-    userPool,
-    authFlows: {
-      userPassword: true,
-    },
-    oAuth: {
-      flows: {
-        implicitCodeGrant: true,
-      },
-      scopes: [
-        cognito.OAuthScope.EMAIL,
-        cognito.OAuthScope.OPENID,
-        cognito.OAuthScope.PROFILE,
-      ],
-      callbackUrls: [applicationEndpointUrl || "https://localhost:3000/"],
-      defaultRedirectUri: applicationEndpointUrl,
-      logoutUrls: [applicationEndpointUrl || "https://localhost:3000/"],
-    },
-    supportedIdentityProviders,
-    generateSecret: false,
-  });
+  // const userPoolClient = new cognito.UserPoolClient(scope, "UserPoolClient", {
+  //   userPoolClientName: `${stage}-user-pool-client`,
+  //   userPool,
+  //   authFlows: {
+  //     userPassword: true,
+  //   },
+  //   oAuth: {
+  //     flows: {
+  //       implicitCodeGrant: true,
+  //     },
+  //     scopes: [
+  //       cognito.OAuthScope.EMAIL,
+  //       cognito.OAuthScope.OPENID,
+  //       cognito.OAuthScope.PROFILE,
+  //     ],
+  //     callbackUrls: [applicationEndpointUrl || "https://localhost:3000/"],
+  //     defaultRedirectUri: applicationEndpointUrl,
+  //     logoutUrls: [applicationEndpointUrl || "https://localhost:3000/"],
+  //   },
+  //   supportedIdentityProviders,
+  //   generateSecret: false,
+  // });
 
-  (userPoolClient.node
-    .defaultChild as cognito.CfnUserPoolClient).addPropertyOverride(
-    "ExplicitAuthFlows",
-    ["ADMIN_NO_SRP_AUTH", "USER_PASSWORD_AUTH"]
-  );
+  // (userPoolClient.node
+  //   .defaultChild as cognito.CfnUserPoolClient).addPropertyOverride(
+  //   "ExplicitAuthFlows",
+  //   ["ADMIN_NO_SRP_AUTH", "USER_PASSWORD_AUTH"]
+  // );
 
-  const userPoolDomain = new cognito.UserPoolDomain(scope, "UserPoolDomain", {
-    userPool,
-    cognitoDomain: { domainPrefix: `${stage}-login-user-pool-client` },
-  });
+  // const userPoolDomain = new cognito.UserPoolDomain(scope, "UserPoolDomain", {
+  //   userPool,
+  //   cognitoDomain: { domainPrefix: `${stage}-login-user-pool-client` },
+  // });
 
-  const identityPool = new cognito.CfnIdentityPool(
-    scope,
-    "CognitoIdentityPool",
-    {
-      identityPoolName: `${stage}IdentityPool`,
-      allowUnauthenticatedIdentities: false,
-      cognitoIdentityProviders: [
-        {
-          clientId: userPoolClient.userPoolClientId,
-          providerName: userPool.userPoolProviderName,
-        },
-      ],
-    }
-  );
+  // const identityPool = new cognito.CfnIdentityPool(
+  //   scope,
+  //   "CognitoIdentityPool",
+  //   {
+  //     identityPoolName: `${stage}IdentityPool`,
+  //     allowUnauthenticatedIdentities: false,
+  //     cognitoIdentityProviders: [
+  //       {
+  //         clientId: userPoolClient.userPoolClientId,
+  //         providerName: userPool.userPoolProviderName,
+  //       },
+  //     ],
+  //   }
+  // );
 
-  const cognitoAuthRole = new iam.Role(scope, "CognitoAuthRole", {
-    permissionsBoundary: iamPermissionsBoundary,
-    path: iamPath,
-    assumedBy: new iam.FederatedPrincipal(
-      "cognito-identity.amazonaws.com",
-      {
-        StringEquals: {
-          "cognito-identity.amazonaws.com:aud": identityPool.ref,
-        },
-        "ForAnyValue:StringLike": {
-          "cognito-identity.amazonaws.com:amr": "authenticated",
-        },
-      },
-      "sts:AssumeRoleWithWebIdentity"
-    ),
-    inlinePolicies: {
-      CognitoAuthorizedPolicy: new iam.PolicyDocument({
-        statements: [
-          new iam.PolicyStatement({
-            actions: [
-              "mobileanalytics:PutEvents",
-              "cognito-sync:*",
-              "cognito-identity:*",
-            ],
-            resources: ["*"],
-            effect: iam.Effect.ALLOW,
-          }),
-          new iam.PolicyStatement({
-            actions: ["execute-api:Invoke"],
-            resources: [
-              `arn:aws:execute-api:${Aws.REGION}:${Aws.ACCOUNT_ID}:${restApiId}/*`,
-            ],
-            effect: iam.Effect.ALLOW,
-          }),
-        ],
-      }),
-    },
-  });
+  // const cognitoAuthRole = new iam.Role(scope, "CognitoAuthRole", {
+  //   permissionsBoundary: iamPermissionsBoundary,
+  //   path: iamPath,
+  //   assumedBy: new iam.FederatedPrincipal(
+  //     "cognito-identity.amazonaws.com",
+  //     {
+  //       StringEquals: {
+  //         "cognito-identity.amazonaws.com:aud": identityPool.ref,
+  //       },
+  //       "ForAnyValue:StringLike": {
+  //         "cognito-identity.amazonaws.com:amr": "authenticated",
+  //       },
+  //     },
+  //     "sts:AssumeRoleWithWebIdentity"
+  //   ),
+  //   inlinePolicies: {
+  //     CognitoAuthorizedPolicy: new iam.PolicyDocument({
+  //       statements: [
+  //         new iam.PolicyStatement({
+  //           actions: [
+  //             "mobileanalytics:PutEvents",
+  //             "cognito-sync:*",
+  //             "cognito-identity:*",
+  //           ],
+  //           resources: ["*"],
+  //           effect: iam.Effect.ALLOW,
+  //         }),
+  //         new iam.PolicyStatement({
+  //           actions: ["execute-api:Invoke"],
+  //           resources: [
+  //             `arn:aws:execute-api:${Aws.REGION}:${Aws.ACCOUNT_ID}:${restApiId}/*`,
+  //           ],
+  //           effect: iam.Effect.ALLOW,
+  //         }),
+  //       ],
+  //     }),
+  //   },
+  // });
 
-  new cognito.CfnIdentityPoolRoleAttachment(scope, "CognitoIdentityPoolRoles", {
-    identityPoolId: identityPool.ref,
-    roles: { authenticated: cognitoAuthRole.roleArn },
-  });
+  // new cognito.CfnIdentityPoolRoleAttachment(scope, "CognitoIdentityPoolRoles", {
+  //   identityPoolId: identityPool.ref,
+  //   roles: { authenticated: cognitoAuthRole.roleArn },
+  // });
 
-  let bootstrapUsersFunction;
+  // let bootstrapUsersFunction;
 
   if (bootstrapUsersPasswordArn) {
-    const lambdaApiRole = new iam.Role(scope, "BootstrapUsersLambdaApiRole", {
+    // const lambdaApiRole =
+    new iam.Role(scope, "BootstrapUsersLambdaApiRole", {
       permissionsBoundary: iamPermissionsBoundary,
       path: iamPath,
       assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
@@ -220,11 +221,11 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
               resources: ["arn:aws:logs:*:*:*"],
               effect: iam.Effect.ALLOW,
             }),
-            new iam.PolicyStatement({
-              actions: ["*"],
-              resources: [userPool.userPoolArn],
-              effect: iam.Effect.ALLOW,
-            }),
+            // new iam.PolicyStatement({
+            //   actions: ["*"],
+            //   resources: [userPool.userPoolArn],
+            //   effect: iam.Effect.ALLOW,
+            // }),
             new iam.PolicyStatement({
               actions: ["ssm:GetParameter"],
               resources: [bootstrapUsersPasswordArn],
@@ -234,83 +235,84 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
         }),
       },
     });
-
-    // TODO: test deploy and watch performance with scope using lambda.Function vs lambda_nodejs.NodejsFunction
-    bootstrapUsersFunction = new lambda_nodejs.NodejsFunction(
-      scope,
-      "bootstrapUsers",
-      {
-        entry: "services/ui-auth/handlers/createUsers.js",
-        handler: "handler",
-        runtime: lambda.Runtime.NODEJS_20_X,
-        timeout: Duration.seconds(60),
-        role: lambdaApiRole,
-        environment: {
-          userPoolId: userPool.userPoolId,
-          bootstrapUsersPasswordArn: bootstrapUsersPasswordArn,
-        },
-      }
-    );
   }
+    // TODO: test deploy and watch performance with scope using lambda.Function vs lambda_nodejs.NodejsFunction
+  //   bootstrapUsersFunction = new lambda_nodejs.NodejsFunction(
+  //     scope,
+  //     "bootstrapUsers",
+  //     {
+  //       entry: "services/ui-auth/handlers/createUsers.js",
+  //       handler: "handler",
+  //       runtime: lambda.Runtime.NODEJS_20_X,
+  //       timeout: Duration.seconds(60),
+  //       role: lambdaApiRole,
+  //       environment: {
+  //         userPoolId: userPool.userPoolId,
+  //         bootstrapUsersPasswordArn: bootstrapUsersPasswordArn,
+  //       },
+  //     }
+  //   );
+  // }
 
-  const webAcl = new WafConstruct(
+  // const webAcl =
+  new WafConstruct(
     scope,
     "CognitoWafConstruct",
     { name: `ui-auth-${stage}-webacl-waf` },
     "REGIONAL"
   ).webAcl;
 
-  new wafv2.CfnWebACLAssociation(scope, "CognitoUserPoolWAFAssociation", {
-    resourceArn: userPool.userPoolArn,
-    webAclArn: webAcl.attrArn,
-  });
+  // new wafv2.CfnWebACLAssociation(scope, "CognitoUserPoolWAFAssociation", {
+  //   resourceArn: userPool.userPoolArn,
+  //   webAclArn: webAcl.attrArn,
+  // });
 
-  new ssm.StringParameter(scope, "CognitoUserPoolIdParameter", {
-    parameterName: `/${stage}/ui-auth/cognito_user_pool_id`,
-    stringValue: userPool.userPoolId,
-  });
-  new ssm.StringParameter(scope, "CognitoUserPoolClientIdParameter", {
-    parameterName: `/${stage}/ui-auth/cognito_user_pool_client_id`,
-    stringValue: userPoolClient.userPoolClientId,
-  });
+  // new ssm.StringParameter(scope, "CognitoUserPoolIdParameter", {
+  //   parameterName: `/${stage}/ui-auth/cognito_user_pool_id`,
+  //   stringValue: userPool.userPoolId,
+  // });
+  // new ssm.StringParameter(scope, "CognitoUserPoolClientIdParameter", {
+  //   parameterName: `/${stage}/ui-auth/cognito_user_pool_client_id`,
+  //   stringValue: userPoolClient.userPoolClientId,
+  // });
 
-  if (bootstrapUsersFunction) {
-    const bootstrapUsersInvoke = new cr.AwsCustomResource(
-      scope,
-      "InvokeBootstrapUsersFunction",
-      {
-        onCreate: {
-          service: "Lambda",
-          action: "invoke",
-          parameters: {
-            FunctionName: bootstrapUsersFunction.functionName,
-            InvocationType: "Event",
-            Payload: JSON.stringify({}),
-          },
-          physicalResourceId: cr.PhysicalResourceId.of(
-            `InvokeBootstrapUsersFunction-${stage}`
-          ),
-        },
-        onUpdate: undefined,
-        onDelete: undefined,
-        policy: cr.AwsCustomResourcePolicy.fromStatements([
-          new iam.PolicyStatement({
-            actions: ["lambda:InvokeFunction"],
-            resources: [bootstrapUsersFunction.functionArn],
-          }),
-        ]),
-        role: props.customResourceRole,
-        resourceType: "Custom::InvokeBootstrapUsersFunction",
-      }
-    );
+  // if (bootstrapUsersFunction) {
+  //   const bootstrapUsersInvoke = new cr.AwsCustomResource(
+  //     scope,
+  //     "InvokeBootstrapUsersFunction",
+  //     {
+  //       onCreate: {
+  //         service: "Lambda",
+  //         action: "invoke",
+  //         parameters: {
+  //           FunctionName: bootstrapUsersFunction.functionName,
+  //           InvocationType: "Event",
+  //           Payload: JSON.stringify({}),
+  //         },
+  //         physicalResourceId: cr.PhysicalResourceId.of(
+  //           `InvokeBootstrapUsersFunction-${stage}`
+  //         ),
+  //       },
+  //       onUpdate: undefined,
+  //       onDelete: undefined,
+  //       policy: cr.AwsCustomResourcePolicy.fromStatements([
+  //         new iam.PolicyStatement({
+  //           actions: ["lambda:InvokeFunction"],
+  //           resources: [bootstrapUsersFunction.functionArn],
+  //         }),
+  //       ]),
+  //       role: props.customResourceRole,
+  //       resourceType: "Custom::InvokeBootstrapUsersFunction",
+  //     }
+  //   );
 
-    bootstrapUsersInvoke.node.addDependency(bootstrapUsersFunction);
-  }
+  //   bootstrapUsersInvoke.node.addDependency(bootstrapUsersFunction);
+  // }
 
   return {
-    userPoolDomainName: userPoolDomain.domainName,
-    identityPoolId: identityPool.ref,
-    userPoolId: userPool.userPoolId,
-    userPoolClientId: userPoolClient.userPoolClientId,
+    // userPoolDomainName: userPoolDomain.domainName,
+    // identityPoolId: identityPool.ref,
+    // userPoolId: userPool.userPoolId,
+    // userPoolClientId: userPoolClient.userPoolClientId,
   };
 }

--- a/deployment/stacks/ui.ts
+++ b/deployment/stacks/ui.ts
@@ -93,20 +93,6 @@ export function createUiComponents(props: CreateUiComponentsProps) {
     }
   );
 
-  // new cloudfront.Distribution(
-  //   scope,
-  //   'CloudFrontDistribution',
-  //   {
-  //     defaultBehavior: {
-  //       origin: new cloudfrontOrigins.HttpOrigin(
-  //         'www.example.com',
-  //         { originId: 'Default'}
-  //       ),
-  //       cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
-  //     },
-  //   }
-  // );
-
   const distribution = new cloudfront.Distribution(
     scope,
     "CloudFrontDistribution",

--- a/deployment/stacks/with_imports/parent.ts
+++ b/deployment/stacks/with_imports/parent.ts
@@ -15,17 +15,7 @@ export class WithImportsParentStack extends Stack {
   ) {
     super(scope, id, props);
 
-    const {
-      stage,
-      oktaMetadataUrl,
-    } = props;
-
     createUiComponents({scope: this});
-
-    createUiAuthComponents({
-      scope: this,
-      stage,
-      oktaMetadataUrl,
-    });
+    createUiAuthComponents({scope: this});
   }
 }

--- a/deployment/stacks/with_imports/parent.ts
+++ b/deployment/stacks/with_imports/parent.ts
@@ -15,7 +15,15 @@ export class WithImportsParentStack extends Stack {
   ) {
     super(scope, id, props);
 
+    const {
+      stage,
+    } = props;
+
     createUiComponents({scope: this});
-    createUiAuthComponents({scope: this});
+
+    createUiAuthComponents({
+      scope: this,
+      stage,
+    });
   }
 }

--- a/deployment/stacks/with_imports/parent.ts
+++ b/deployment/stacks/with_imports/parent.ts
@@ -20,7 +20,6 @@ export class WithImportsParentStack extends Stack {
     } = props;
 
     createUiComponents({scope: this});
-
     createUiAuthComponents({
       scope: this,
       stage,

--- a/deployment/stacks/with_imports/parent.ts
+++ b/deployment/stacks/with_imports/parent.ts
@@ -1,0 +1,31 @@
+import { Construct } from "constructs";
+import {
+  Stack,
+  StackProps,
+} from "aws-cdk-lib";
+import { DeploymentConfigProperties } from "../../deployment-config";
+import { createUiComponents } from "./ui";
+import { createUiAuthComponents } from "./ui-auth";
+
+export class WithImportsParentStack extends Stack {
+  constructor(
+    scope: Construct,
+    id: string,
+    props: StackProps & DeploymentConfigProperties
+  ) {
+    super(scope, id, props);
+
+    const {
+      stage,
+      oktaMetadataUrl,
+    } = props;
+
+    createUiComponents({scope: this});
+
+    createUiAuthComponents({
+      scope: this,
+      stage,
+      oktaMetadataUrl,
+    });
+  }
+}

--- a/deployment/stacks/with_imports/ui-auth.ts
+++ b/deployment/stacks/with_imports/ui-auth.ts
@@ -1,0 +1,61 @@
+import { Construct } from "constructs";
+import {
+  aws_cognito as cognito,
+} from "aws-cdk-lib";
+
+interface CreateUiAuthComponentsProps {
+  scope: Construct;
+  stage: string;
+  oktaMetadataUrl: string;
+}
+
+export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
+  const {
+    scope,
+    // stage,
+    // oktaMetadataUrl,
+  } = props;
+
+  const userPool = new cognito.UserPool(scope, "UserPool");
+
+  // if (oktaMetadataUrl) {
+  //   new cognito.CfnUserPoolIdentityProvider(
+  //     scope,
+  //     "CognitoUserPoolIdentityProvider",
+  //     {
+  //       userPoolId: userPool.userPoolId,
+  //       providerName: "Okta",
+  //       providerType: "SAML",
+  //       providerDetails: {
+  //         MetadataURL: oktaMetadataUrl,
+  //       },
+  //     }
+  //   );
+  // }
+
+  const userPoolClient = new cognito.UserPoolClient(scope, "UserPoolClient", { userPool });
+
+  // const userPoolDomain = new cognito.UserPoolDomain(scope, "UserPoolDomain", {
+  //   userPool,
+  //   cognitoDomain: { domainPrefix: `${stage}-login-user-pool-client` },
+  // });
+
+  const identityPool = new cognito.CfnIdentityPool(
+    scope,
+    "CognitoIdentityPool",
+    {
+      allowUnauthenticatedIdentities: false,
+    }
+  );
+
+  new cognito.CfnIdentityPoolRoleAttachment(scope, "CognitoIdentityPoolRoles", {
+    identityPoolId: identityPool.ref,
+  });
+
+  return {
+    // userPoolDomainName: userPoolDomain.domainName,
+    identityPoolId: identityPool.ref,
+    userPoolId: userPool.userPoolId,
+    userPoolClientId: userPoolClient.userPoolClientId,
+  };
+}

--- a/deployment/stacks/with_imports/ui-auth.ts
+++ b/deployment/stacks/with_imports/ui-auth.ts
@@ -5,40 +5,20 @@ import {
 
 interface CreateUiAuthComponentsProps {
   scope: Construct;
-  stage: string;
-  oktaMetadataUrl: string;
 }
 
 export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
   const {
     scope,
-    // stage,
-    // oktaMetadataUrl,
   } = props;
 
-  const userPool = new cognito.UserPool(scope, "UserPool");
+  const userPool = new cognito.UserPool(scope, "UserPool", {
+    signInAliases: {
+      email: true,
+    },
+  });
 
-  // if (oktaMetadataUrl) {
-  //   new cognito.CfnUserPoolIdentityProvider(
-  //     scope,
-  //     "CognitoUserPoolIdentityProvider",
-  //     {
-  //       userPoolId: userPool.userPoolId,
-  //       providerName: "Okta",
-  //       providerType: "SAML",
-  //       providerDetails: {
-  //         MetadataURL: oktaMetadataUrl,
-  //       },
-  //     }
-  //   );
-  // }
-
-  const userPoolClient = new cognito.UserPoolClient(scope, "UserPoolClient", { userPool });
-
-  // const userPoolDomain = new cognito.UserPoolDomain(scope, "UserPoolDomain", {
-  //   userPool,
-  //   cognitoDomain: { domainPrefix: `${stage}-login-user-pool-client` },
-  // });
+  new cognito.UserPoolClient(scope, "UserPoolClient", { userPool });
 
   const identityPool = new cognito.CfnIdentityPool(
     scope,
@@ -51,11 +31,4 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
   new cognito.CfnIdentityPoolRoleAttachment(scope, "CognitoIdentityPoolRoles", {
     identityPoolId: identityPool.ref,
   });
-
-  return {
-    // userPoolDomainName: userPoolDomain.domainName,
-    identityPoolId: identityPool.ref,
-    userPoolId: userPool.userPoolId,
-    userPoolClientId: userPoolClient.userPoolClientId,
-  };
 }

--- a/deployment/stacks/with_imports/ui-auth.ts
+++ b/deployment/stacks/with_imports/ui-auth.ts
@@ -5,17 +5,42 @@ import {
 
 interface CreateUiAuthComponentsProps {
   scope: Construct;
+  stage: string;
 }
 
 export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
   const {
     scope,
+    stage,
   } = props;
 
   const userPool = new cognito.UserPool(scope, "UserPool", {
+    userPoolName: `${stage}-user-pool`,
     signInAliases: {
       email: true,
     },
+    autoVerify: {
+      email: true,
+    },
+    selfSignUpEnabled: false,
+    standardAttributes: {
+      givenName: {
+        required: false,
+        mutable: true,
+      },
+      familyName: {
+        required: false,
+        mutable: true,
+      },
+      phoneNumber: {
+        required: false,
+        mutable: true,
+      },
+    },
+    customAttributes: {
+      ismemberof: new cognito.StringAttribute({ mutable: true }),
+    },
+    advancedSecurityMode: cognito.AdvancedSecurityMode.ENFORCED,
   });
 
   new cognito.UserPoolClient(scope, "UserPoolClient", { userPool });

--- a/deployment/stacks/with_imports/ui-auth.ts
+++ b/deployment/stacks/with_imports/ui-auth.ts
@@ -14,7 +14,7 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
     stage,
   } = props;
 
-  const userPool = new cognito.UserPool(scope, "UserPool", {
+  new cognito.UserPool(scope, "UserPool", {
     userPoolName: `${stage}-user-pool`,
     signInAliases: {
       email: true,
@@ -41,19 +41,5 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
       ismemberof: new cognito.StringAttribute({ mutable: true }),
     },
     advancedSecurityMode: cognito.AdvancedSecurityMode.ENFORCED,
-  });
-
-  new cognito.UserPoolClient(scope, "UserPoolClient", { userPool });
-
-  const identityPool = new cognito.CfnIdentityPool(
-    scope,
-    "CognitoIdentityPool",
-    {
-      allowUnauthenticatedIdentities: false,
-    }
-  );
-
-  new cognito.CfnIdentityPoolRoleAttachment(scope, "CognitoIdentityPoolRoles", {
-    identityPoolId: identityPool.ref,
   });
 }

--- a/deployment/stacks/with_imports/ui.ts
+++ b/deployment/stacks/with_imports/ui.ts
@@ -1,0 +1,29 @@
+import { Construct } from "constructs";
+import {
+  aws_cloudfront as cloudfront,
+  aws_cloudfront_origins as cloudfrontOrigins,
+} from "aws-cdk-lib";
+
+interface CreateUiComponentsProps {
+  scope: Construct;
+}
+
+export function createUiComponents(props: CreateUiComponentsProps) {
+  const {
+    scope,
+  } = props;
+
+  new cloudfront.Distribution(
+    scope,
+    'CloudFrontDistribution',
+    {
+      defaultBehavior: {
+        origin: new cloudfrontOrigins.HttpOrigin(
+          'www.example.com',
+          { originId: 'Default'}
+        ),
+        cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
+      },
+    }
+  );
+}

--- a/deployment/stacks/without_imports/parent.ts
+++ b/deployment/stacks/without_imports/parent.ts
@@ -1,0 +1,16 @@
+import { Construct } from "constructs";
+import {
+  Stack,
+  StackProps,
+} from "aws-cdk-lib";
+import { DeploymentConfigProperties } from "../../deployment-config";
+
+export class WithoutImportsParentStack extends Stack {
+  constructor(
+    scope: Construct,
+    id: string,
+    props: StackProps & DeploymentConfigProperties
+  ) {
+    super(scope, id, props);
+  }
+}

--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -14,9 +14,9 @@ provider:
   name: aws
   runtime: nodejs20.x
   region: us-east-1
-  stackTags:  
+  stackTags:
     PROJECT: ${self:custom.project}
-    SERVICE: ${self:service}  
+    SERVICE: ${self:service}
   iam:
     role:
       # Even though we are creating our own IAM role that is used in each lambda function below
@@ -155,7 +155,7 @@ resources:
       Properties:
         ResourceArn: !GetAtt CognitoUserPool.Arn
         WebACLArn: !GetAtt WafPluginAcl.Arn
-        
+
     CognitoUserPoolClient:
       Type: AWS::Cognito::UserPoolClient
       Properties:

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -11,9 +11,9 @@ provider:
   name: aws
   runtime: nodejs20.x
   region: us-east-1
-  stackTags:  
+  stackTags:
     PROJECT: ${self:custom.project}
-    SERVICE: ${self:service}  
+    SERVICE: ${self:service}
 
 custom:
   project: "seds"

--- a/src/run.ts
+++ b/src/run.ts
@@ -209,7 +209,7 @@ async function deploy(options: { stage: string }) {
   const stage = options.stage;
   const runner = new LabeledProcessRunner();
   await prepare_services(runner);
-  const deployCmd = ["cdk", "deploy", "--context", `stage=${stage}`, "--all"];
+  const deployCmd = ["cdk", "deploy", "--context", `stage=${stage}`, "--method=direct", "--all"];
   await runner.run_command_and_output("CDK deploy", deployCmd, ".");
 }
 


### PR DESCRIPTION
### Description
This mostly tweaks the way we are doing the importing so that the main cdk setup can be used as is and we just run special commands during importing. For more details check out `deployment/import_instructions.md`.

### Related ticket(s)
CMDCT-4194

---
### How to test
You are welcome to try following the `deployment/import_instructions.md` and see if it all makes sense and enables you to import resources from a serverless stack.


### Notes
NA

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
