### PR TITLE
Fix state abbr sorting edge case in user table

### DIFF
--- a/services/ui-src/src/components/Users/Users.jsx
+++ b/services/ui-src/src/components/Users/Users.jsx
@@ -28,9 +28,13 @@ const Users = () => {
 
   const loadUserData = async () => {
     const userList = await listUsers();
-    userList.sort((a, b) => a.username?.localeCompare(b.username));
-    for (let user of userList) {
-      user.states?.sort();
+    if (userList) {
+      userList.sort((a, b) => a.username?.localeCompare(b.username));
+      for (let user of userList) {
+        if (Array.isArray(user.states)) {
+          user.states.sort();
+        }
+      }
     }
     setUsers(userList);
   };

--- a/services/ui-src/src/components/Users/Users.jsx
+++ b/services/ui-src/src/components/Users/Users.jsx
@@ -31,6 +31,8 @@ const Users = () => {
     if (userList) {
       userList.sort((a, b) => a.username?.localeCompare(b.username));
       for (let user of userList) {
+        // Sometimes user.states is a string instead of an array.
+        // TODO: Perform a migration to fix that. Should always be an array.
         if (Array.isArray(user.states)) {
           user.states.sort();
         }


### PR DESCRIPTION
### Description
Typically, users have a `states` property that is an array of state abbreviations associated with that user. Sometimes that property may be missing. Sometimes it may be a string instead.

With this PR, we will handle those cases gracefully, and still display the table as best we can.

Eventually, I intend to circle back and run migrations to ensure `user.states` is always a string array - but today is not that day.

### Related ticket(s)
n/a

---
### How to test
To view the user table, log in as admin and choose "View / Edit Users". The table will display fine, as it always has, because our seed data doesn't contain any of these edge cases.

You could test the logic by making manual updates in DynamoDB, locally or in this environment's branch. To be frank, I think the easiest way to test will be to merge this PR and see if the user table loads again in dev, where the bad user data already is.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
