### PR TITLE
Disallow editing of user properties that come from Cognito

### DIFF
--- a/services/app-api/handlers/users/post/updateUser.js
+++ b/services/app-api/handlers/users/post/updateUser.js
@@ -19,6 +19,8 @@ export const main = handler(async (event, context) => {
     await authorizeAdmin(event);
   }
 
+  assertPayloadIsValid(data);
+
   const params = {
     TableName:
       process.env.AUTH_USER_TABLE_NAME ?? process.env.AuthUserTableName,
@@ -26,13 +28,11 @@ export const main = handler(async (event, context) => {
       userId: currentUser["Items"][0].userId,
     },
     UpdateExpression:
-      "SET username = :username, #r = :role, states = :states, lastLogin = :lastLogin, usernameSub = :usernameSub",
+      "SET #r = :role, states = :states, lastLogin = :lastLogin",
     ExpressionAttributeValues: {
-      ":username": data.username,
       ":role": data.role,
       ":states": data.states ?? "",
       ":lastLogin": new Date().toISOString(),
-      ":usernameSub": data.usernameSub ?? null,
     },
     ExpressionAttributeNames: {
       "#r": "role",
@@ -50,4 +50,31 @@ function modifyingAnythingButAnEmptyStateList(incomingUser, existingUser) {
   if (incomingUser.usernameSub !== existingUser.usernameSub) return true;
   if (existingUser.states.length > 0) return true;
   return false;
+}
+
+function assertPayloadIsValid (data) {
+  if (!data) {
+    throw new Error("User update payload is missing");
+  }
+
+  if (typeof data.role !== "string" || !data.role) {
+    throw new Error("Invalid user role - must be a nonempty string");
+  }
+  if (!["admin", "business", "state"].includes(data.role)) {
+    throw new Error("Invalid user role - must be an existing role");
+  }
+
+  if (data.states && data.states !== "null") {
+    if (!Array.isArray(data.states)) {
+      throw new Error("Invalid user states - must be an array");
+    }
+    for (let state of data.states) {
+      if (typeof state !== "string") {
+        throw new Error("Invalid user states - must be strings");
+      }
+      if (!/^[A-Z]{2}$/.test(state)) {
+        throw new Error("Invalid user states - must be 2-letter abbreviations");
+      }
+    }
+  }
 }

--- a/services/ui-src/src/components/EditUser/EditUser.jsx
+++ b/services/ui-src/src/components/EditUser/EditUser.jsx
@@ -176,6 +176,7 @@ const EditUser = ({ stateList }) => {
                     value={user.username}
                     type="text"
                     onChange={e => updateLocalUser(e, "username")}
+                    disabled={true}
                     name="username"
                     className="form-input"
                   />

--- a/services/ui-src/src/components/EditUser/EditUser.test.jsx
+++ b/services/ui-src/src/components/EditUser/EditUser.test.jsx
@@ -144,16 +144,17 @@ describe("Test EditUser.js", () => {
     renderComponent(mockUser);
     await waitFor(() => expect(getUserById).toHaveBeenCalled());
 
-    const table = screen.getByTestId("table");
-    const usernameInput = table.querySelector(".userName input");
-    userEvent.type(usernameInput, "TY");
+    const roleDropdown = screen.getByPlaceholderText("Select a Role");
+    userEvent.click(roleDropdown);
+    const adminOption = screen.getByText("Admin User");
+    userEvent.click(adminOption);
 
     const saveButton = screen.getByText("Update User", { selector: "button" });
     userEvent.click(saveButton);
 
     expect(updateUser).toHaveBeenCalledWith(
       expect.objectContaining({
-        username: "QWERTY"
+        role: "admin",
       })
     );
   });


### PR DESCRIPTION
### Description
This PR locks down the username field of the EditUser page (which is visible only to admins). Previously, this page could be used to change the username, but there shouldn't be a need to do so - username will come from Cognito.

There is a possibility that this functionality will be needed in the future; requirements analysis is ongoing, and we may someday add this ability back.

This PR also adds stricter validation for the fields that _can_ be updated from the EditUser page.

### Related ticket(s)
CMDCT-4234

---
### How to test
1. Log in as an admin user
2. Go to View / Edit Users
3. Click a username to go to the Edit page
4. Note that the username field is disabled - as are all string fields
5. Attempt to edit role or state. Note that the update succeeds.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
