### PR TITLE
CMDCT-4338 adds conditional nature of IpSets (missed in original PR)

### DIFF
--- a/deployment/deployment-config.ts
+++ b/deployment/deployment-config.ts
@@ -10,8 +10,8 @@ export interface DeploymentConfigProperties {
   bootstrapUsersPassword?: string;
   cloudfrontCertificateArn?: string;
   cloudfrontDomainName?: string;
-  vpnIpSetArn: string;
-  vpnIpv6SetArn: string;
+  vpnIpSetArn?: string;
+  vpnIpv6SetArn?: string;
   brokerString: string;
 }
 
@@ -66,8 +66,6 @@ function validateConfig(config: {
     "stage",
     "vpcName",
     "oktaMetadataUrl",
-    "vpnIpSetArn",
-    "vpnIpv6SetArn",
     "brokerString",
   ];
 

--- a/deployment/stacks/ui.ts
+++ b/deployment/stacks/ui.ts
@@ -20,10 +20,10 @@ interface CreateUiComponentsProps {
   isDev: boolean;
   iamPermissionsBoundary: IManagedPolicy;
   iamPath: string;
-  cloudfrontCertificateArn: string;
-  cloudfrontDomainName: string;
-  vpnIpSetArn: string;
-  vpnIpv6SetArn: string;
+  cloudfrontCertificateArn?: string;
+  cloudfrontDomainName?: string;
+  vpnIpSetArn?: string;
+  vpnIpv6SetArn?: string;
 }
 
 export function createUiComponents(props: CreateUiComponentsProps) {
@@ -172,8 +172,8 @@ function setupWaf(
   scope: Construct,
   stage: string,
   project: string,
-  vpnIpSetArn: string,
-  vpnIpv6SetArn: string,
+  vpnIpSetArn?: string,
+  vpnIpv6SetArn?: string,
 ) {
   const wafRules: wafv2.CfnWebACL.RuleProperty[] = [];
 


### PR DESCRIPTION
### Description
IpSets are not present (by design) in production. This must be accounted for in config.

### Related ticket(s)
CMDCT-4338

---
### How to test
Check that application works (I've deployed it with sed-default temporarily devoid of ipsets config to simulate prod)


### Notes
NA

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
