### PR TITLE
CMDCT-4360 - termination protection + always invalidation + okta always

### DIFF
--- a/deployment/stacks/deployFrontend.ts
+++ b/deployment/stacks/deployFrontend.ts
@@ -112,6 +112,7 @@ export function deployFrontend(props: DeployFrontendProps) {
         userPoolId,
         userPoolClientId,
         userPoolClientDomain,
+        timestamp: new Date().toISOString(),
       },
     }
   );

--- a/deployment/stacks/deployFrontend.ts
+++ b/deployment/stacks/deployFrontend.ts
@@ -5,6 +5,7 @@ import {
   Duration,
   aws_s3 as s3,
   aws_s3_deployment as s3_deployment,
+  custom_resources as cr,
 } from "aws-cdk-lib";
 import path from "path";
 import { execSync } from "node:child_process";
@@ -29,12 +30,15 @@ export function deployFrontend(props: DeployFrontendProps) {
   const {
     scope,
     stage,
+    distribution,
     apiGatewayRestApiUrl,
     applicationEndpointUrl,
     identityPoolId,
     userPoolId,
     userPoolClientId,
     userPoolClientDomain,
+    iamPermissionsBoundary,
+    iamPath
   } = props;
 
   const reactAppPath = "./services/ui-src/";
@@ -48,8 +52,8 @@ export function deployFrontend(props: DeployFrontendProps) {
 
   const deploymentRole = new iam.Role(scope, "BucketDeploymentRole", {
     assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
-    path: props.iamPath,
-    permissionsBoundary: props.iamPermissionsBoundary,
+    path: iamPath,
+    permissionsBoundary: iamPermissionsBoundary,
   });
 
   deploymentRole.addToPolicy(
@@ -108,10 +112,36 @@ export function deployFrontend(props: DeployFrontendProps) {
         userPoolId,
         userPoolClientId,
         userPoolClientDomain,
-        timestamp: new Date().toISOString(),
       },
     }
   );
 
   deployTimeConfig.node.addDependency(deployWebsite);
+
+  const invalidateCloudfront = new cr.AwsCustomResource(
+    scope,
+    "InvalidateCloudfront",
+    {
+      onCreate: undefined,
+      onDelete: undefined,
+      onUpdate: {
+        service: "CloudFront",
+        action: "createInvalidation",
+        parameters: {
+          DistributionId: distribution.distributionId,
+          InvalidationBatch: {
+            Paths: {
+              Quantity: 1,
+              Items: ["/*"],
+            },
+            CallerReference: new Date().toISOString(),
+          },
+        },
+        physicalResourceId: cr.PhysicalResourceId.of(`InvalidateCloudfront-${stage}`),
+      },
+      role: deploymentRole,
+    }
+  );
+
+  invalidateCloudfront.node.addDependency(deployTimeConfig);
 }

--- a/deployment/stacks/env-config.template.js
+++ b/deployment/stacks/env-config.template.js
@@ -11,5 +11,4 @@ window._env_ = {
   COGNITO_REDIRECT_SIGNIN: "{{applicationEndpointUrl}}",
   COGNITO_REDIRECT_SIGNOUT: "{{applicationEndpointUrl}}",
   STAGE: "{{stage}}",
-  TIMESTAMP: "{{timestamp}}",
 };

--- a/deployment/stacks/env-config.template.js
+++ b/deployment/stacks/env-config.template.js
@@ -11,4 +11,5 @@ window._env_ = {
   COGNITO_REDIRECT_SIGNIN: "{{applicationEndpointUrl}}",
   COGNITO_REDIRECT_SIGNOUT: "{{applicationEndpointUrl}}",
   STAGE: "{{stage}}",
+  TIMESTAMP: "{{timestamp}}",
 };

--- a/deployment/stacks/parent.ts
+++ b/deployment/stacks/parent.ts
@@ -23,12 +23,15 @@ export class ParentStack extends Stack {
     id: string,
     props: StackProps & DeploymentConfigProperties
   ) {
-    super(scope, id, props);
+    const { vpcName, isDev } = props;
+
+    super(scope, id, {
+      ...props,
+      terminationProtection: !isDev,
+    });
 
     const iamPermissionsBoundaryArn = `arn:aws:iam::${Aws.ACCOUNT_ID}:policy/cms-cloud-admin/developer-boundary-policy`
     const iamPath = "/delegatedadmin/developer/"
-
-    const { vpcName } = props;
 
     const commonProps = {
       scope: this,

--- a/deployment/stacks/ui-auth.ts
+++ b/deployment/stacks/ui-auth.ts
@@ -78,37 +78,38 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
   let supportedIdentityProviders:
     | cognito.UserPoolClientIdentityProvider[]
     | undefined = undefined;
+  let oktaIdp:
+    | cognito.CfnUserPoolIdentityProvider
+    | undefined = undefined;
 
-  if (oktaMetadataUrl) {
-    const providerName = "Okta";
+  const providerName = "Okta";
 
-    new cognito.CfnUserPoolIdentityProvider(
-      scope,
-      "CognitoUserPoolIdentityProvider",
-      {
-        providerName,
-        providerType: "SAML",
-        userPoolId: userPool.userPoolId,
-        providerDetails: {
-          MetadataURL: oktaMetadataUrl,
-        },
-        attributeMapping: {
-          email:
-            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
-          family_name:
-            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
-          given_name:
-            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
-          "custom:ismemberof": "ismemberof",
-        },
-        idpIdentifiers: ["IdpIdentifier"],
-      }
-    );
+  oktaIdp = new cognito.CfnUserPoolIdentityProvider(
+    scope,
+    "CognitoUserPoolIdentityProvider",
+    {
+      providerName,
+      providerType: "SAML",
+      userPoolId: userPool.userPoolId,
+      providerDetails: {
+        MetadataURL: oktaMetadataUrl,
+      },
+      attributeMapping: {
+        email:
+          "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+        family_name:
+          "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
+        given_name:
+          "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
+        "custom:ismemberof": "ismemberof",
+      },
+      idpIdentifiers: ["IdpIdentifier"],
+    }
+  );
 
-    supportedIdentityProviders = [
-      cognito.UserPoolClientIdentityProvider.custom(providerName),
-    ];
-  }
+  supportedIdentityProviders = [
+    cognito.UserPoolClientIdentityProvider.custom(providerName),
+  ];
 
   const appUrl =
   secureCloudfrontDomainName || applicationEndpointUrl || "https://localhost:3000/";
@@ -134,6 +135,8 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
     supportedIdentityProviders,
     generateSecret: false,
   });
+
+  userPoolClient.node.addDependency(oktaIdp);
 
   (
     userPoolClient.node.defaultChild as cognito.CfnUserPoolClient


### PR DESCRIPTION
### Description
A few things we've realized are better than not having for termination protection, invalidating cloudfront consistently, and always assuming okta will be there (because it will, even if it doesn't always work).

### Related ticket(s)
CMDCT-4360

---
### How to test
Use the app, it should still work :)


### Notes
I tested pushing a commit with no changes to make sure it created an invalidation still and it did:
<img width="661" alt="image" src="https://github.com/user-attachments/assets/9ba981e5-ef33-453f-b42c-b20ede53ec84" />
https://github.com/Enterprise-CMCS/macpro-mdct-seds/actions/runs/13633717265/job/38107202761
<img width="1123" alt="image" src="https://github.com/user-attachments/assets/7e394e88-0591-48ae-80bf-5041832229ee" />


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
