### PR TITLE
CMDCT-4390 - fixes kafka getting non-existent tables

### DIFF
--- a/deployment/constructs/lambda-dynamo-event.ts
+++ b/deployment/constructs/lambda-dynamo-event.ts
@@ -30,6 +30,9 @@ export class LambdaDynamoEventSource extends Construct {
       handler,
       memorySize = 1024,
       tables,
+      iamPermissionsBoundary,
+      iamPath,
+      stackName,
       timeout = Duration.seconds(6),
       ...restProps
     } = props;
@@ -41,8 +44,8 @@ export class LambdaDynamoEventSource extends Construct {
           "service-role/AWSLambdaVPCAccessExecutionRole"
         ),
       ],
-      permissionsBoundary: props.iamPermissionsBoundary,
-      path: props.iamPath,
+      permissionsBoundary: iamPermissionsBoundary,
+      path: iamPath,
       inlinePolicies: {
         LambdaPolicy: new iam.PolicyDocument({
           statements: [
@@ -68,7 +71,7 @@ export class LambdaDynamoEventSource extends Construct {
 
     // TODO: test deploy and watch performance with this using lambda.Function vs lambda_nodejs.NodejsFunction
     this.lambda = new lambda_nodejs.NodejsFunction(this, id, {
-      functionName: `${props.stackName}-${id}`,
+      functionName: `${stackName}-${id}`,
       handler,
       runtime: lambda.Runtime.NODEJS_20_X,
       timeout,

--- a/deployment/deployment-config.ts
+++ b/deployment/deployment-config.ts
@@ -15,6 +15,7 @@ export interface DeploymentConfigProperties {
   vpnIpSetArn?: string;
   vpnIpv6SetArn?: string;
   brokerString: string;
+  kafkaAuthorizedSubnetIds: string;
 }
 
 export const determineDeploymentConfig = async (stage: string) => {
@@ -73,6 +74,7 @@ function validateConfig(config: {
     "vpcName",
     "oktaMetadataUrl",
     "brokerString",
+    "kafkaAuthorizedSubnetIds",
   ];
 
   const invalidKeys = expectedKeys.filter(

--- a/deployment/stacks/api.ts
+++ b/deployment/stacks/api.ts
@@ -15,6 +15,7 @@ import {
 import { Lambda } from "../constructs/lambda";
 import { WafConstruct } from "../constructs/waf";
 import { addIamPropertiesToBucketAutoDeleteRole } from "../utils/s3";
+import { getSubnets } from "../utils/vpc";
 import { LambdaDynamoEventSource } from "../constructs/lambda-dynamo-event";
 import { DynamoDBTableIdentifiers } from "../constructs/dynamodb-table";
 import { isDefined } from "../utils/misc";
@@ -25,8 +26,8 @@ interface CreateApiComponentsProps {
   stage: string;
   project: string;
   isDev: boolean;
-  vpc: ec2.IVpc;
-  privateSubnets: ec2.ISubnet[];
+  vpcName: string;
+  kafkaAuthorizedSubnetIds: string;
   tables: DynamoDBTableIdentifiers[];
   brokerString: string;
   iamPermissionsBoundary: iam.IManagedPolicy;
@@ -39,8 +40,8 @@ export function createApiComponents(props: CreateApiComponentsProps) {
     stage,
     project,
     isDev,
-    vpc,
-    privateSubnets,
+    vpcName,
+    kafkaAuthorizedSubnetIds,
     tables,
     brokerString,
     iamPermissionsBoundary,
@@ -49,6 +50,9 @@ export function createApiComponents(props: CreateApiComponentsProps) {
 
   const service = "app-api";
   Tags.of(scope).add("SERVICE", service);
+
+  const vpc = ec2.Vpc.fromLookup(scope, "Vpc", { vpcName });
+  const kafkaAuthorizedSubnets = getSubnets(scope, kafkaAuthorizedSubnetIds)
 
   const kafkaSecurityGroup = new ec2.SecurityGroup(
     scope,
@@ -188,7 +192,7 @@ export function createApiComponents(props: CreateApiComponentsProps) {
     memorySize: 2048,
     retryAttempts: 2,
     vpc,
-    vpcSubnets: { subnets: privateSubnets },
+    vpcSubnets: { subnets: kafkaAuthorizedSubnets },
     securityGroups: [kafkaSecurityGroup],
     ...commonProps,
     tables,
@@ -213,7 +217,7 @@ export function createApiComponents(props: CreateApiComponentsProps) {
     memorySize: 2048,
     retryAttempts: 2,
     vpc,
-    vpcSubnets: { subnets: privateSubnets },
+    vpcSubnets: { subnets: kafkaAuthorizedSubnets },
     securityGroups: [kafkaSecurityGroup],
     ...commonProps,
     tables: dataConnectTables,

--- a/deployment/stacks/parent.ts
+++ b/deployment/stacks/parent.ts
@@ -1,7 +1,6 @@
 import { Construct } from "constructs";
 import {
   Aws,
-  aws_ec2 as ec2,
   aws_iam as iam,
   CfnOutput,
   Stack,
@@ -12,7 +11,6 @@ import { createDataComponents } from "./data";
 import { createUiAuthComponents } from "./ui-auth";
 import { createUiComponents } from "./ui";
 import { createApiComponents } from "./api";
-import { sortSubnets } from "../utils/vpc";
 import { deployFrontend } from "./deployFrontend";
 import { createCustomResourceRole } from "./customResourceRole";
 import { isLocalStack } from "../local/util";
@@ -23,7 +21,7 @@ export class ParentStack extends Stack {
     id: string,
     props: StackProps & DeploymentConfigProperties
   ) {
-    const { vpcName, isDev } = props;
+    const { isDev } = props;
 
     super(scope, id, {
       ...props,
@@ -44,9 +42,6 @@ export class ParentStack extends Stack {
       iamPath,
     };
 
-    const vpc = ec2.Vpc.fromLookup(this, "Vpc", { vpcName });
-    const privateSubnets = sortSubnets(vpc.privateSubnets).slice(0, 3);
-
     const { customResourceRole } = createCustomResourceRole({ ...commonProps });
 
     const { tables } = createDataComponents({
@@ -56,8 +51,6 @@ export class ParentStack extends Stack {
 
     const { apiGatewayRestApiUrl, restApiId } = createApiComponents({
       ...commonProps,
-      vpc,
-      privateSubnets,
       tables
     });
 

--- a/deployment/utils/vpc.ts
+++ b/deployment/utils/vpc.ts
@@ -1,5 +1,5 @@
 import { Construct } from "constructs";
-import * as ec2 from "aws-cdk-lib/aws-ec2";
+import { aws_ec2 as ec2 } from "aws-cdk-lib";
 
 export function getSubnets(
   scope: Construct,

--- a/deployment/utils/vpc.ts
+++ b/deployment/utils/vpc.ts
@@ -1,19 +1,11 @@
-import { aws_ec2 as ec2 } from "aws-cdk-lib";
+import { Construct } from "constructs";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
 
-function getSubnetSize(cidrBlock: string): number {
-  const subnetMask = parseInt(cidrBlock.split("/")[1], 10);
-  return Math.pow(2, 32 - subnetMask);
-}
-
-export function sortSubnets(subnets: ec2.ISubnet[]): ec2.ISubnet[] {
-  return subnets.sort((a, b) => {
-    const sizeA = getSubnetSize(a.ipv4CidrBlock);
-    const sizeB = getSubnetSize(b.ipv4CidrBlock);
-
-    if (sizeA !== sizeB) {
-      return sizeB - sizeA; // Sort by size in decreasing order
-    }
-
-    return a.subnetId.localeCompare(b.subnetId); // Sort by name if sizes are equal
-  });
+export function getSubnets(
+  scope: Construct,
+  subnetIds: string
+): ec2.ISubnet[] {
+  return subnetIds.split(',').map(subnetId =>
+    ec2.Subnet.fromSubnetId(scope, `Subnet-${subnetId}`, subnetId)
+  )
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@types/node": "^20.12.7",
     "@types/yargs": "^15.0.10",
-    "aws-cdk": "^2.182.0",
+    "aws-cdk": "2.179.0",
     "aws-cdk-local": "^2.19.2",
     "chromedriver": ">=88.0.0",
     "dotenv": "^8.2.0",
@@ -43,7 +43,7 @@
     "@aws-sdk/client-lambda": "^3.678.0",
     "@aws-sdk/client-s3": "^3.670.0",
     "@aws-sdk/client-secrets-manager": "^3.670.0",
-    "aws-cdk-lib": "^2.182.0",
+    "aws-cdk-lib": "2.179.0",
     "constructs": "^10.3.0",
     "source-map-support": "^0.5.21"
   }

--- a/services/app-api/handlers/kafka/post/dataConnectSource.js
+++ b/services/app-api/handlers/kafka/post/dataConnectSource.js
@@ -3,7 +3,6 @@ import KafkaSourceLib from "../../../libs/kafka-source-lib.js";
 class DataConnectTransform extends KafkaSourceLib {
   topicPrefix = "aws.mdct.seds.cdc";
   tables = [
-    "age-ranges",
     "auth-user",
     "form-answers",
     "form-questions",
@@ -11,7 +10,6 @@ class DataConnectTransform extends KafkaSourceLib {
     "forms",
     "state-forms",
     "states",
-    "status",
   ];
 
   createPayload(record) {

--- a/services/app-api/handlers/kafka/post/postKafkaData.js
+++ b/services/app-api/handlers/kafka/post/postKafkaData.js
@@ -4,7 +4,6 @@ class PostKafkaData extends KafkaSourceLib {
   topicPrefix = "aws.mdct.seds.cdc";
   version = "v0";
   tables = [
-    "age-ranges",
     "auth-user",
     "form-answers",
     "form-questions",
@@ -12,7 +11,6 @@ class PostKafkaData extends KafkaSourceLib {
     "forms",
     "state-forms",
     "states",
-    "status",
   ];
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,10 +12,10 @@
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz#6d3c7860354d4856a7e75375f2f0ecab313b4989"
   integrity sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==
 
-"@aws-cdk/cloud-assembly-schema@^40.6.0":
-  version "40.7.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-40.7.0.tgz#1d53d55fc616477965338f0de98192ec3a3ed9bc"
-  integrity sha512-00wVKn9pOOGXbeNwA4E8FUFt0zIB4PmSO7PvIiDWgpaFX3G/sWyy0A3s6bg/n2Yvkghu8r4a8ckm+mAzkAYmfA==
+"@aws-cdk/cloud-assembly-schema@^39.2.0":
+  version "39.2.20"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-39.2.20.tgz#38aa92ba98c21b8e04f2d4c788969e567fd5921a"
+  integrity sha512-RI7S8jphGA8mak154ElnEJQPNTTV4PZmA7jgqnBBHQGyOPJIXxtACubNQ5m4YgjpkK3UJHsWT+/cOAfM/Au/Wg==
   dependencies:
     jsonschema "~1.4.1"
     semver "^7.7.1"
@@ -2443,14 +2443,14 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-aws-cdk-lib@^2.182.0:
-  version "2.182.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.182.0.tgz#9b2d51f41d1c7846a62c1d6f6a7da5e677db43d3"
-  integrity sha512-emymzTJiCpPz8oF++oiFvFuLH1QZjv6NRNQGn7VuDrEewZFTM4VpiVco5NrxH+KCWnXquDBPF5sQIUo6HY7jLg==
+aws-cdk-lib@2.179.0:
+  version "2.179.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.179.0.tgz#18d1989de157fb21fe280fce3fb63feced5dfe5c"
+  integrity sha512-fwkoEzvh3TXYj+GPkyq/GSQt63JJV1dBgDKwr3xRdb8lQaPntSclmisa+ARO8tjPfkru1NqxAFQTtiqtAE83cA==
   dependencies:
     "@aws-cdk/asset-awscli-v1" "^2.2.208"
     "@aws-cdk/asset-node-proxy-agent-v6" "^2.1.0"
-    "@aws-cdk/cloud-assembly-schema" "^40.6.0"
+    "@aws-cdk/cloud-assembly-schema" "^39.2.0"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
     fs-extra "^11.2.0"
@@ -2470,10 +2470,10 @@ aws-cdk-local@^2.19.2:
   dependencies:
     diff "^5.0.0"
 
-aws-cdk@^2.182.0:
-  version "2.1003.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-2.1003.0.tgz#db3bcd839f86b9b7f0f3d2d3359cefb768458462"
-  integrity sha512-FORPDGW8oUg4tXFlhX+lv/j+152LO9wwi3/CwNr1WY3c3HwJUtc0fZGb2B3+Fzy6NhLWGHJclUsJPEhjEt8Nhg==
+aws-cdk@2.179.0:
+  version "2.179.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-2.179.0.tgz#4caa93c54df4c9a586d03afb7423dfbf23f5997c"
+  integrity sha512-aA2+8S2g4UBQHkUEt0mYd16VLt/ucR+QfyUJi34LDKRAhOCNDjPCZ4z9z/JEDyuni0BdzsYA55pnpDN9tMULpA==
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
### Description
This will fix a kafka problem. Hopefully that's all we need to do.

### Related ticket(s)
CMDCT-4390

---
### How to test
Check postKafta and dataConnect logs to see there is no error.

### Notes
Also, super uncool but I had to change the version for cdk because the internet is a spooky place.
How does this work?:
https://github.com/aws/aws-cdk/releases
Says the latest version is 2.182.0
<img width="576" alt="image" src="https://github.com/user-attachments/assets/3ff20b11-1435-4824-b55e-50a53ae3d3da" />

Then check out yarn's versions
https://yarnpkg.com/package?q=aws-cdk&name=aws-cdk
<img width="617" alt="image" src="https://github.com/user-attachments/assets/4d49b0e5-e76a-451b-bd4a-4883caf1e8e4" />
There they've removed 2.182.0 and added several with the middle number in the thousands. The thousands introduces some things we'll need to change.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
