### PR TITLE
Fix run local issue with new subnet code

### DIFF
--- a/deployment/stacks/api.ts
+++ b/deployment/stacks/api.ts
@@ -52,7 +52,8 @@ export function createApiComponents(props: CreateApiComponentsProps) {
   Tags.of(scope).add("SERVICE", service);
 
   const vpc = ec2.Vpc.fromLookup(scope, "Vpc", { vpcName });
-  const kafkaAuthorizedSubnets = getSubnets(scope, kafkaAuthorizedSubnetIds)
+  const kafkaAuthorizedSubnets =
+    getSubnets(scope, kafkaAuthorizedSubnetIds) || vpc.privateSubnets;
 
   const kafkaSecurityGroup = new ec2.SecurityGroup(
     scope,

--- a/deployment/utils/vpc.ts
+++ b/deployment/utils/vpc.ts
@@ -1,11 +1,14 @@
 import { Construct } from "constructs";
 import { aws_ec2 as ec2 } from "aws-cdk-lib";
 
-export function getSubnets(
-  scope: Construct,
-  subnetIds: string
-): ec2.ISubnet[] {
-  return subnetIds.split(',').map(subnetId =>
-    ec2.Subnet.fromSubnetId(scope, `Subnet-${subnetId}`, subnetId)
-  )
+export function getSubnets(scope: Construct, subnetIds: string) {
+  if (!subnetIds) {
+    return undefined;
+  } else {
+    return subnetIds
+      .split(",")
+      .map((subnetId) =>
+        ec2.Subnet.fromSubnetId(scope, `Subnet-${subnetId}`, subnetId)
+      );
+  }
 }


### PR DESCRIPTION
### Description
Fix run local issue with new subnet code.  @peoplespete what do you think about this fix?  I don't like that with this fix, if we forget to define kafkaAuthorizedSubnetIds in the deployment secret, the kafka lambda functions will have the same error as before, but as long as that is defined that issue is correct and run local will work as before without that needing to be defined.

### Related ticket(s)
CMDCT-4414

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
