### PR TITLE
CMDCT-4415 - removing ECR references from cdk bootstrap process

### DIFF
--- a/deployment/bootstrap-template.yaml
+++ b/deployment/bootstrap-template.yaml
@@ -20,10 +20,6 @@ Parameters:
     Description: Empty to create a new key (default), 'AWS_MANAGED_KEY' to use a managed S3 key, or the ID/ARN of an existing key.
     Default: ""
     Type: String
-  ContainerAssetsRepositoryName:
-    Description: A user-provided custom name to use for the container assets ECR repository
-    Default: ""
-    Type: String
   Qualifier:
     Description: An identifier to distinguish multiple bootstrap stacks in the same environment
     Default: hnb659fds
@@ -93,11 +89,6 @@ Conditions:
       - Fn::Equals:
           - ""
           - Ref: InputPermissionsBoundary
-  HasCustomContainerAssetsRepositoryName:
-    Fn::Not:
-      - Fn::Equals:
-          - ""
-          - Ref: ContainerAssetsRepositoryName
   UsePublicAccessBlockConfiguration:
     Fn::Equals:
       - "true"
@@ -228,50 +219,6 @@ Resources:
             Condition:
               Bool: { "aws:SecureTransport": "false" }
             Principal: "*"
-  ContainerAssetsRepository:
-    Type: AWS::ECR::Repository
-    Properties:
-      ImageTagMutability: IMMUTABLE
-      # Untagged images should never exist but Security Hub wants this rule to exist
-      LifecyclePolicy:
-        LifecyclePolicyText: |
-          {
-            "rules": [
-              {
-                "rulePriority": 1,
-                "description": "Untagged images should not exist, but expire any older than one year",
-                "selection": {
-                  "tagStatus": "untagged",
-                  "countType": "sinceImagePushed",
-                  "countUnit": "days",
-                  "countNumber": 365
-                },
-                "action": { "type": "expire" }
-              }
-            ]
-          }
-      RepositoryName:
-        Fn::If:
-          - HasCustomContainerAssetsRepositoryName
-          - Fn::Sub: "${ContainerAssetsRepositoryName}"
-          - Fn::Sub: cdk-${Qualifier}-container-assets-${AWS::AccountId}-${AWS::Region}
-      RepositoryPolicyText:
-        Version: "2012-10-17"
-        Statement:
-          # Necessary for Lambda container images
-          # https://docs.aws.amazon.com/lambda/latest/dg/configuration-images.html#configuration-images-permissions
-          - Sid: LambdaECRImageRetrievalPolicy
-            Effect: Allow
-            Principal: { Service: "lambda.amazonaws.com" }
-            Action:
-              - ecr:BatchGetImage
-              - ecr:GetDownloadUrlForLayer
-            Condition:
-              StringLike:
-                "aws:sourceArn":
-                  {
-                    "Fn::Sub": "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:*",
-                  }
   FilePublishingRole:
     Type: AWS::IAM::Role
     Properties:
@@ -305,39 +252,6 @@ Resources:
       Tags:
         - Key: aws-cdk:bootstrap-role
           Value: file-publishing
-  ImagePublishingRole:
-    Type: AWS::IAM::Role
-    Properties:
-      Path: /delegatedadmin/developer/
-      PermissionsBoundary:
-        Fn::Sub: arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/cms-cloud-admin/ct-ado-poweruser-permissions-boundary-policy
-      AssumeRolePolicyDocument:
-        Statement:
-          # allows this role to be assumed with session tags.
-          # see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html#id_session-tags_permissions-required
-          - Action: sts:TagSession
-            Effect: Allow
-            Principal:
-              AWS:
-                Ref: AWS::AccountId
-          - Action: sts:AssumeRole
-            Effect: Allow
-            Principal:
-              AWS:
-                Ref: AWS::AccountId
-          - Fn::If:
-              - HasTrustedAccounts
-              - Action: sts:AssumeRole
-                Effect: Allow
-                Principal:
-                  AWS:
-                    Ref: TrustedAccounts
-              - Ref: AWS::NoValue
-      RoleName:
-        Fn::Sub: cdk-${Qualifier}-image-publishing-role-${AWS::AccountId}-${AWS::Region}
-      Tags:
-        - Key: aws-cdk:bootstrap-role
-          Value: image-publishing
   LookupRole:
     Type: AWS::IAM::Role
     Properties:
@@ -429,33 +343,6 @@ Resources:
         - Ref: FilePublishingRole
       PolicyName:
         Fn::Sub: cdk-${Qualifier}-file-publishing-role-default-policy-${AWS::AccountId}-${AWS::Region}
-  ImagePublishingRoleDefaultPolicy:
-    Type: AWS::IAM::Policy
-    Properties:
-      PolicyDocument:
-        Statement:
-          - Action:
-              - ecr:PutImage
-              - ecr:InitiateLayerUpload
-              - ecr:UploadLayerPart
-              - ecr:CompleteLayerUpload
-              - ecr:BatchCheckLayerAvailability
-              - ecr:DescribeRepositories
-              - ecr:DescribeImages
-              - ecr:BatchGetImage
-              - ecr:GetDownloadUrlForLayer
-            Resource:
-              Fn::Sub: "${ContainerAssetsRepository.Arn}"
-            Effect: Allow
-          - Action:
-              - ecr:GetAuthorizationToken
-            Resource: "*"
-            Effect: Allow
-        Version: "2012-10-17"
-      Roles:
-        - Ref: ImagePublishingRole
-      PolicyName:
-        Fn::Sub: cdk-${Qualifier}-image-publishing-role-default-policy-${AWS::AccountId}-${AWS::Region}
   DeploymentActionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -686,10 +573,6 @@ Outputs:
     Export:
       Name:
         Fn::Sub: CdkBootstrap-${Qualifier}-FileAssetKeyArn
-  ImageRepositoryName:
-    Description: The name of the ECR repository which hosts docker image assets
-    Value:
-      Fn::Sub: "${ContainerAssetsRepository}"
   # The Output is used by the CLI to verify the version of the bootstrap resources.
   BootstrapVersion:
     Description: The version of the bootstrap resources that are currently mastered in this stack


### PR DESCRIPTION
### Description
The ECR references are not required and we can still deploy our apps without them.

### Related ticket(s)
CMDCT-4415

---
### How to test
Notice that there are no ECR repositories in dev seds account
yet you can log into functioning app: https://d1bxv0wjippz35.cloudfront.net/

### Notes
NA

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
