### PR TITLE
Move calculateFormQuarterFromDate to its own file

### DIFF
--- a/services/app-api/handlers/forms/post/generateQuarterForms.js
+++ b/services/app-api/handlers/forms/post/generateQuarterForms.js
@@ -9,6 +9,7 @@ import {
   getAnswersSet,
 } from "../../shared/sharedFunctions.js";
 import { authorizeAdmin } from "../../../auth/authConditions.js";
+import { calculateFormQuarterFromDate } from "../../../libs/time.js";
 
 /** Called from the API; admin access required */
 export const main = handler(async (event, context) => {
@@ -353,30 +354,4 @@ const generateQuarterForms = async (event) => {
     status: 200,
     message: `Forms successfully created for Quarter ${specifiedQuarter} of ${specifiedYear}`,
   };
-};
-
-/**
- * We run an automated process at the start of each quarter,
- * which generates forms for the previous quarter.
- * For example: on Jan 1 2024, we would generate forms for Oct-Dec 2023.
- * Those forms would be due for completion by Jan 31, 2024.
- *
- * A potential source of confusion is that Oct-Dec 2023 represents the
- * federal fiscal quarter 2024 Q1; a quarter ahead of what you may expect.
- * Another potential source is that we want to generate forms for the
- * _previous_ quarter, to report on data from the recent past.
- *
- * Happily, these off-by-one issues cancel each other out. So this
- * function returns the more common quarter number of the current date.
- *
- * @param { Date } date - The current date
- * @returns { Object } { year, quarter } -
- *          The Federal Fiscal Quarter for which forms should be generated
- */
-export const calculateFormQuarterFromDate = (date) => {
-  let year = date.getFullYear();
-  let month = date.getMonth();
-  let quarter = Math.floor(month / 3) + 1;
-
-  return { year, quarter };
 };

--- a/services/app-api/handlers/forms/post/generateQuarterForms.test.js
+++ b/services/app-api/handlers/forms/post/generateQuarterForms.test.js
@@ -17,10 +17,6 @@ import { mockClient } from "aws-sdk-client-mock";
 
 /*
  * Coverage notes:
- *   * The function calculateFormQuarterFromDate is untested,
- *     because doing so in place would require shimming `new Date()`
- *     TODO: move this function to a different file,
- *     and test it later in its new home.
  *   * The inner function batchWriteAll has retry logic that is untested here,
  *     because that logic is broken. It checked UnprocessedItems.length,
  *     but UnprocessedItems is an object and not an array.
@@ -30,9 +26,7 @@ import { mockClient } from "aws-sdk-client-mock";
  *     value in unit testing that logic.
  */
 
-// TODO: remove this mock, once we've moved calculateFormQuarterFromDate
-vi.mock("./generateQuarterForms.js", async (importOriginal) => ({
-  ...(await importOriginal()),
+vi.mock("../../../libs/time.js", () => ({
   calculateFormQuarterFromDate: vi.fn().mockReturnValue({ year: 2025, quarter: 1 }),
 }));
 
@@ -410,7 +404,7 @@ describe("generateQuarterForms.js", () => {
       statusCode: 200,
       body: JSON.stringify({
         status: 200,
-        message: "Forms successfully created for Quarter 1 of 2025",
+        message: "Forms successfully created for Quarter 1 of 2025"
       }),
     }));
 

--- a/services/app-api/libs/time.js
+++ b/services/app-api/libs/time.js
@@ -1,0 +1,25 @@
+/**
+ * We run an automated process at the start of each quarter,
+ * which generates forms for the previous quarter.
+ * For example: on Jan 1 2024, we would generate forms for Oct-Dec 2023.
+ * Those forms would be due for completion by Jan 31, 2024.
+ *
+ * A potential source of confusion is that Oct-Dec 2023 represents the
+ * federal fiscal quarter 2024 Q1; a quarter ahead of what you may expect.
+ * Another potential source is that we want to generate forms for the
+ * _previous_ quarter, to report on data from the recent past.
+ *
+ * Happily, these off-by-one issues cancel each other out. So this
+ * function returns the more common quarter number of the current date.
+ *
+ * @param { Date } date - The current date
+ * @returns { Object } { year, quarter } -
+ *          The Federal Fiscal Quarter for which forms should be generated
+ */
+export const calculateFormQuarterFromDate = (date) => {
+  let year = date.getFullYear();
+  let month = date.getMonth();
+  let quarter = Math.floor(month / 3) + 1;
+
+  return { year, quarter };
+};

--- a/services/app-api/libs/time.test.js
+++ b/services/app-api/libs/time.test.js
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { calculateFormQuarterFromDate } from "./time.js";
+
+describe("calculateFormQuarterFromDate", () => {
+  it("should calculate the correct quarter for a given date", () => {
+    const date = new Date(2025, 1, 1);
+    const result = calculateFormQuarterFromDate(date);
+    expect(result.year).toBe(2025);
+    expect(result.quarter).toBe(1);
+  });
+});


### PR DESCRIPTION
### Description
Putting time-related functions in their own file makes them easier to mock when unit testing other business logic.

In fact, this fixes the tests for generateQuarterForms, which were failing because this function was _not_ being mocked.

I don't know what was wrong with my mocking code before, but it is now simpler and definitely works.


### Related ticket(s)
n/a

---
### How to test
This PR has no intentional behavioral changes. If the unit tests pass, we're in good shape.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
