### PR TITLE
CMDCT-4622 gets cloudfront logging to stop breaking destroys for ephemeral apps

### DIFF
--- a/.github/workflows/git-secrets.yaml
+++ b/.github/workflows/git-secrets.yaml
@@ -6,6 +6,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run gitleaks docker
-        uses: docker://zricethezav/gitleaks
+        uses: docker://zricethezav/gitleaks:v8.24.3
         with:
           args: detect --source /github/workspace/ --no-git --verbose

--- a/deployment/stacks/ui-auth.ts
+++ b/deployment/stacks/ui-auth.ts
@@ -138,7 +138,8 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
   const userPoolDomain = new cognito.UserPoolDomain(scope, "UserPoolDomain", {
     userPool,
     cognitoDomain: {
-      domainPrefix: userPoolDomainPrefix ?? `${stage}-login-user-pool-client`,
+      domainPrefix:
+        userPoolDomainPrefix ?? `${project}-${stage}-login-user-pool-client`,
     },
   });
 

--- a/deployment/stacks/ui.ts
+++ b/deployment/stacks/ui.ts
@@ -42,25 +42,36 @@ export function createUiComponents(props: CreateUiComponentsProps) {
     enforceSSL: true,
   });
 
-  const logBucket = new s3.Bucket(scope, "CloudfrontLogBucket", {
-    encryption: s3.BucketEncryption.S3_MANAGED,
-    publicReadAccess: false,
-    blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-    objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_PREFERRED,
-    removalPolicy: isDev ? RemovalPolicy.DESTROY : RemovalPolicy.RETAIN,
-    autoDeleteObjects: isDev,
-    enforceSSL: true,
-  });
+  let loggingConfig:
+    | { enableLogging: boolean; logBucket: s3.Bucket }
+    | undefined;
+  if (!isDev) {
+    // this bucket is not created for ephemeral environments because the delete of the bucket often fails because it doesn't decouple from the distribution gracefully
+    // should you need to test these parts of the infrastructure out the easiest method is to add your branch's name to the isDev definition in deployment-config.ts
+    const logBucket = new s3.Bucket(scope, "CloudfrontLogBucket", {
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      publicReadAccess: false,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_PREFERRED,
+      removalPolicy: RemovalPolicy.RETAIN,
+      enforceSSL: true,
+      versioned: true,
+    });
 
-  // Add bucket policy to allow CloudFront to write logs
-  logBucket.addToResourcePolicy(
-    new iam.PolicyStatement({
-      effect: iam.Effect.ALLOW,
-      principals: [new iam.ServicePrincipal("cloudfront.amazonaws.com")],
-      actions: ["s3:PutObject"],
-      resources: [`${logBucket.bucketArn}/*`],
-    })
-  );
+    logBucket.addToResourcePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        principals: [new iam.ServicePrincipal("cloudfront.amazonaws.com")],
+        actions: ["s3:PutObject"],
+        resources: [`${logBucket.bucketArn}/*`],
+      })
+    );
+
+    loggingConfig = {
+      enableLogging: true,
+      logBucket,
+    };
+  }
 
   const securityHeadersPolicy = new cloudfront.ResponseHeadersPolicy(
     scope,
@@ -113,8 +124,7 @@ export function createUiComponents(props: CreateUiComponentsProps) {
         responseHeadersPolicy: securityHeadersPolicy,
       },
       defaultRootObject: "index.html",
-      enableLogging: true,
-      logBucket: logBucket,
+      ...loggingConfig,
       httpVersion: cloudfront.HttpVersion.HTTP2,
       errorResponses: [
         {


### PR DESCRIPTION
### Description
This change will mean that we no longer have issues destroying branches which destroys the stack.


### Related ticket(s)
CMDCT-4622

---
### How to test
The app still works the same.

### Notes
NA

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
