### PR TITLE
add lifecycle rule for log expiration

### DIFF
--- a/deployment/stacks/ui.ts
+++ b/deployment/stacks/ui.ts
@@ -67,6 +67,12 @@ export function createUiComponents(props: CreateUiComponentsProps) {
       versioned: true,
       serverAccessLogsBucket: loggingBucket,
       serverAccessLogsPrefix: `AWSLogs/${Aws.ACCOUNT_ID}/s3/`,
+      lifecycleRules: [
+        {
+          expiration: Duration.days(1095),
+          noncurrentVersionExpiration: Duration.days(1095),
+        },
+      ],
     });
 
     logBucket.grantPut(new iam.ServicePrincipal("cloudfront.amazonaws.com"));


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description

All apps should retain cloudfront logs for 30 months or 3 years

### Related ticket(s)

<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

CMDCT-5123

---

### How to test

<!-- Step-by-step instructions on how to test, if necessary -->

### Notes

<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

<!-- Complete the following steps before merging -->

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->

_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
