### PR TITLE
Improve status_id ETL script

### DIFF
--- a/services/database/scripts/migrateStateFormStatus.js
+++ b/services/database/scripts/migrateStateFormStatus.js
@@ -54,13 +54,20 @@ const awsConfig = {
   region: "us-east-1",
   logger: {
     debug: () => {},
-    info: console.info,
+    info: () => {},
     warn: console.warn,
     error: console.error,
   },
 };
 
 const client = DynamoDBDocumentClient.from(new DynamoDBClient(awsConfig));
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+    hour: "numeric",
+    minute: "numeric",
+    second: "numeric",
+    fractionalSecondDigits: 3
+});
+const logPrefix = () => dateFormatter.format(new Date()) + " | ";
 
 function updateStatusFields (stateForm) {
   const { state_form, status_id, status, not_applicable } = stateForm;
@@ -89,7 +96,7 @@ function updateStatusFields (stateForm) {
      * We expect to see fewer than 20 of these,
      * and we want all of their IDs logged out.
      */
-    console.warn(`Form ${state_form} has an outlier status. [status_id, status, not_applicable] = ${JSON.stringify([status_id, status, not_applicable])}`);
+    console.warn(`${logPrefix()}Form ${state_form} has an outlier status. [status_id, status, not_applicable] = ${JSON.stringify([status_id, status, not_applicable])}`);
   }
 
   if (state_form === "MA-2021-1-64.21E") {
@@ -126,7 +133,7 @@ function updateStatusFields (stateForm) {
 }
 
 async function * iterateStateForms () {
-  console.log("Scanning...");
+  console.log(`${logPrefix()}Scanning...`);
   let pageNumber = 0;
   let totalFormCount = 0;
   for await (let page of paginateScan({ client }, { TableName: STATE_FORMS_TABLE_NAME })) {
@@ -137,9 +144,9 @@ async function * iterateStateForms () {
       totalFormCount += 1;
       yield stateForm;
     }
-    console.log(`Completed scan of page ${pageNumber}; ${pageFormCount} forms processed.`);
+    console.log(`${logPrefix()}Completed scan of page ${pageNumber}; ${pageFormCount} forms processed.`);
   }
-  console.log(`Scan complete; ${totalFormCount} forms in all.`);
+  console.log(`${logPrefix()}Scan complete; ${totalFormCount} forms in all.`);
 }
 
 (async function () {
@@ -155,11 +162,11 @@ async function * iterateStateForms () {
         updatedCount += 1;
       }
     }
-    console.log(`Found ${updatedCount} state forms in need of update.`);
-    console.log("All updates successful.");
+    console.log(`${logPrefix()}Found ${updatedCount} state forms in need of update.`);
+    console.log(`${logPrefix()}All updates successful.`);
   }
   catch (err) {
     console.error(err);
-    console.log(`Updated ${updatedCount} state forms before exiting.`);
+    console.log(`${logPrefix()}Updated ${updatedCount} state forms before exiting.`);
   }
 })();


### PR DESCRIPTION
### Description
* Log less from the DynamoDB client. If something goes wrong it will log that, but if everything is fine it will be quiet.
* Include timestamps in all other log messages.
* Use BatchWriteCommand instead of PutCommand. This required a significant reorganization of the script, and the logging of counts will no longer be 100% accurate in the event of an error. But the speedup takes this script from an estimated ~15 minutes in production to an estimated ~30 seconds. Combined with an expected AWS deployment of 4 minutes and change, that gets us to an estimated 5 minutes for the entire deployment.

This PR replaces #15181.

### Related ticket(s)
CMDCT-3884

---

### How to test
You can't. But I did, in every way I knew how.

### Notes

<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

<!-- Complete the following steps before merging -->

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->

_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
