### PR TITLE
Reduce the number of console errors/warnings

### DIFF
--- a/services/ui-src/src/components/App/App.jsx
+++ b/services/ui-src/src/components/App/App.jsx
@@ -7,6 +7,7 @@ import Footer from "../Footer/Footer";
 import { fireTealiumPageView } from "../../utility-functions/tealium";
 import { useStore } from "../../store/store";
 import "./App.scss";
+import Preloader from "components/Preloader/Preloader";
 
 function App() {
   const loadUser = useStore((state) => state.loadUser);
@@ -37,7 +38,9 @@ function App() {
 
   return (
     <>
-      {!isAuthenticating && (
+      {isAuthenticating ? (
+        <Preloader />
+      ) : (
         <>
           <Header displayHeader={true} />
           <AppContext.Provider value={{ isAuthenticated, setIsAuthenticated }}>

--- a/services/ui-src/src/components/AppRoutes/AppRoutes.test.jsx
+++ b/services/ui-src/src/components/AppRoutes/AppRoutes.test.jsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import AppRoutes from "./AppRoutes";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { useStore } from "../../store/store";
 import { getForm as actualGetForm } from "libs/api";
@@ -80,28 +80,16 @@ describe("App Router", () => {
       { route: "/unauthorized", text: /not authorized/ },
       { route: "/profile", text: /Profile/ },
       { route: "/forms/CO/2026/1", text: /Q1 2026 Reports/ },
-      {
-        route: "/forms/CO/2026/1/21E",
-        text: /Does this form apply/,
-        loadFunc: getForm,
-      },
-      {
-        route: "/print/CO/2026/1/21E",
-        text: "Print / PDF",
-        loadFunc: getForm,
-      },
-    ])("should have route $route", async ({ route, text, loadFunc }) => {
+      { route: "/forms/CO/2026/1/21E", text: /Does this form apply/ },
+      { route: "/print/CO/2026/1/21E", text: "Print / PDF" },
+    ])("should have route $route", async ({ route, text }) => {
       render(
         <MemoryRouter initialEntries={[route]}>
           <AppRoutes />
         </MemoryRouter>
       );
 
-      if (loadFunc) {
-        await waitFor(() => expect(loadFunc).toHaveBeenCalled());
-      }
-
-      expect(screen.getByText(text)).toBeVisible();
+      expect(await screen.findByText(text)).toBeVisible();
     });
 
     it("should show state home page when user has a state", () => {
@@ -159,28 +147,16 @@ describe("App Router", () => {
       { route: "/unauthorized", text: /not authorized/ },
       { route: "/profile", text: /Profile/ },
       { route: "/forms/CO/2026/1", text: /Q1 2026 Reports/ },
-      {
-        route: "/forms/CO/2026/1/21E",
-        text: /Does this form apply/,
-        loadFunc: getForm,
-      },
-      {
-        route: "/print/CO/2026/1/21E",
-        text: "Print / PDF",
-        loadFunc: getForm,
-      },
-    ])("should have route $route", async ({ route, text, loadFunc }) => {
+      { route: "/forms/CO/2026/1/21E", text: /Does this form apply/ },
+      { route: "/print/CO/2026/1/21E", text: "Print / PDF" },
+    ])("should have route $route", async ({ route, text }) => {
       render(
         <MemoryRouter initialEntries={[route]}>
           <AppRoutes />
         </MemoryRouter>
       );
 
-      if (loadFunc) {
-        await waitFor(() => expect(loadFunc).toHaveBeenCalled());
-      }
-
-      expect(screen.getByText(text)).toBeVisible();
+      expect(await screen.findByText(text)).toBeVisible();
     });
 
     it("should show business home page", () => {
@@ -227,33 +203,21 @@ describe("App Router", () => {
       { route: "/unauthorized", text: /not authorized/ },
       { route: "/profile", text: /Profile/ },
       { route: "/forms/CO/2026/1", text: /Q1 2026 Reports/ },
-      {
-        route: "/forms/CO/2026/1/21E",
-        text: /Does this form apply/,
-        loadFunc: getForm,
-      },
-      {
-        route: "/print/CO/2026/1/21E",
-        text: "Print / PDF",
-        loadFunc: getForm,
-      },
+      { route: "/forms/CO/2026/1/21E", text: /Does this form apply/ },
+      { route: "/print/CO/2026/1/21E", text: "Print / PDF" },
       { route: "/users", text: "Users" },
       { route: "/users/42/edit", text: "Edit User" },
       { route: "/form-templates", text: "Add/Edit Form Templates" },
       { route: "/generate-forms", text: "Generate Quarterly Forms" },
       { route: "/generate-counts", text: "Generate Enrollment Totals" },
-    ])("should have route $route", async ({ route, text, loadFunc }) => {
+    ])("should have route $route", async ({ route, text }) => {
       render(
         <MemoryRouter initialEntries={[route]}>
           <AppRoutes />
         </MemoryRouter>
       );
 
-      if (loadFunc) {
-        await waitFor(() => expect(loadFunc).toHaveBeenCalled());
-      }
-
-      expect(screen.getByText(text)).toBeVisible();
+      expect(await screen.findByText(text)).toBeVisible();
     });
 
     it("should show admin home page", () => {

--- a/services/ui-src/src/components/EditUser/EditUser.jsx
+++ b/services/ui-src/src/components/EditUser/EditUser.jsx
@@ -46,8 +46,9 @@ const EditUser = () => {
 
     await updateUser(updatedUser);
     setUser(updatedUser);
+    setRole(updatedUser.role);
+    setState(updatedUser.state);
     alert(`User with username: "${updatedUser.username}" has been updated`);
-    window.location.reload(false);
   };
 
   return (

--- a/services/ui-src/src/components/EditUser/EditUser.test.jsx
+++ b/services/ui-src/src/components/EditUser/EditUser.test.jsx
@@ -106,6 +106,7 @@ describe("Test EditUser.js", () => {
 
   it("should call the API to save updated user details", async () => {
     getUserById.mockResolvedValueOnce(mockUser);
+    vi.stubGlobal("alert", vi.fn());
 
     render(component);
     await waitFor(() => expect(getUserById).toHaveBeenCalled());

--- a/services/ui-src/src/components/FormHeader/FormHeader.jsx
+++ b/services/ui-src/src/components/FormHeader/FormHeader.jsx
@@ -43,7 +43,8 @@ const FormHeader = ({ quarter, form, year, state }) => {
 
   // Saves maximum FPL to the database
   const updateMaxFPL = async () => {
-    await updateFPL(maxFPL).then(() => saveForm());
+    updateFPL(maxFPL);
+    await saveForm();
   };
 
   // Ensure user input is valid for max FPL

--- a/services/ui-src/src/components/FormLoadError/FormLoadError.jsx
+++ b/services/ui-src/src/components/FormLoadError/FormLoadError.jsx
@@ -9,7 +9,7 @@ const FormLoadError = () => {
   return (
     <div data-testid="formLoadTest">
       <div>
-        <div row>
+        <div>
           <div>
             <h1>Error Retrieving Form</h1>
             <p>

--- a/services/ui-src/src/components/FormTemplates/FormTemplates.test.jsx
+++ b/services/ui-src/src/components/FormTemplates/FormTemplates.test.jsx
@@ -94,8 +94,17 @@ describe("Tests for FormTemplates.js", () => {
   });
 
   test("should render an error message when the form has failed to save", async () => {
+    const mockTemplate = { foo: "bar" };
+    listTemplateYears.mockResolvedValue([2021, 2022]);
+    getTemplate.mockResolvedValue({ template: mockTemplate });
     updateTemplate.mockRejectedValue(new Error("mock error text"));
+
     render(<FormTemplates />);
+    await waitFor(() => {
+      expect(listTemplateYears).toHaveBeenCalled();
+      expect(getTemplate).toHaveBeenCalled();
+    });
+
     userEvent.click(screen.getByText("Save", { selector: "button" }));
     await waitFor(() =>
       expect(screen.getByText("Save failed: mock error text")).toBeVisible()

--- a/services/ui-src/src/components/GREGridWithTotals/GREGridWithTotals.jsx
+++ b/services/ui-src/src/components/GREGridWithTotals/GREGridWithTotals.jsx
@@ -232,9 +232,6 @@ const GREGridWithTotals = (props) => {
                       onChange={(event) =>
                         updateGrid(rowIndex, columnIndex, event)
                       }
-                      defaultValue={parseFloat(column).toFixed(
-                        currentPrecision
-                      )}
                       value={addCommas(
                         parseFloat(gridData[rowIndex][columnIndex]).toFixed(
                           currentPrecision
@@ -264,7 +261,6 @@ const GREGridWithTotals = (props) => {
                     onChange={(event) =>
                       updateGrid(rowIndex, columnIndex, event)
                     }
-                    defaultValue={parseFloat(column).toFixed(currentPrecision)}
                     value={addCommas(
                       parseFloat(gridData[rowIndex][columnIndex]).toFixed(
                         currentPrecision

--- a/services/ui-src/src/components/GridWithTotals/GridWithTotals.jsx
+++ b/services/ui-src/src/components/GridWithTotals/GridWithTotals.jsx
@@ -299,9 +299,6 @@ const GridWithTotals = (props) => {
                           updateLocalStateOnChange(rowIndex, columnIndex, event)
                         }
                         onBlur={updateGridOnBlur}
-                        defaultValue={parseFloat(column).toFixed(
-                          currentPrecision
-                        )}
                         value={addCommas(
                           parseFloat(gridData[rowIndex][columnIndex]).toFixed(
                             currentPrecision
@@ -334,9 +331,6 @@ const GridWithTotals = (props) => {
                         updateLocalStateOnChange(rowIndex, columnIndex, event)
                       }
                       onBlur={updateGridOnBlur}
-                      defaultValue={parseFloat(column).toFixed(
-                        currentPrecision
-                      )}
                       value={addCommas(
                         parseFloat(gridData[rowIndex][columnIndex]).toFixed(
                           currentPrecision

--- a/services/ui-src/src/components/Header/Header.test.jsx
+++ b/services/ui-src/src/components/Header/Header.test.jsx
@@ -36,6 +36,10 @@ describe("Test Header.js", () => {
   });
 
   it("should log the user out properly", async () => {
+    const locationSpy = vi.spyOn(window, "location", "get").mockReturnValue({
+      ...window.location,
+      href: "Any string here prevents JSDOM complaints in the test output.",
+    });
     useStore.setState({ wipeUser: vi.fn() });
     signOut.mockResolvedValueOnce();
 
@@ -54,11 +58,24 @@ describe("Test Header.js", () => {
 
     await waitFor(() => expect(signOut).toHaveBeenCalled());
     expect(useStore.getState().wipeUser).toHaveBeenCalled();
+    locationSpy.mockRestore();
   });
 
   it("should not clear user data from the store if Amplify logout fails", async () => {
     useStore.setState({ wipeUser: vi.fn() });
     signOut.mockRejectedValueOnce(new Error("Mock Amplify error"));
+
+    // Swallow this error (but only this error)
+    const spy = vi.spyOn(console, "log").mockImplementation((...args) => {
+      const [message, arg] = args;
+      if (
+        message !== "error signing out:" ||
+        !(arg instanceof Error) ||
+        arg.message !== "Mock Amplify error"
+      ) {
+        throw new Error(arg);
+      }
+    });
 
     render(
       <BrowserRouter>
@@ -74,23 +91,8 @@ describe("Test Header.js", () => {
     userEvent.click(logoutButton);
 
     await waitFor(() => expect(signOut).toHaveBeenCalled());
+    spy.mockRestore();
     expect(useStore.getState().wipeUser).not.toHaveBeenCalled();
-  });
-  test("Test logout", async () => {
-    signOut.mockResolvedValueOnce();
-    render(
-      <BrowserRouter>
-        <Header />
-      </BrowserRouter>
-    );
-
-    await waitFor(() => expect(screen.getByText("My Profile")).toBeVisible());
-    const myProfileBtn = screen.getByRole("button", { name: "My Profile" });
-    userEvent.click(myProfileBtn);
-
-    const logoutBtn = screen.getByRole("button", { name: "Logout" });
-    userEvent.click(logoutBtn);
-    expect(signOut).toHaveBeenCalled();
   });
 
   test("Should opens Reporting Instruction file in a new tab", async () => {

--- a/services/ui-src/src/components/HomeAdmin/HomeAdmin.test.jsx
+++ b/services/ui-src/src/components/HomeAdmin/HomeAdmin.test.jsx
@@ -6,6 +6,11 @@ import { render, waitFor, screen } from "@testing-library/react";
 import { useStore } from "../../store/store";
 import userEvent from "@testing-library/user-event";
 import { buildSortedAccordionByYearQuarter } from "utility-functions/sortingFunctions";
+import { listFormsForState } from "../../libs/api";
+
+vi.mock("../../libs/api", () => ({
+  listFormsForState: vi.fn(),
+}));
 
 vi.mock("../../libs/contextLib", () => ({
   useAppContext: vi.fn(),
@@ -25,7 +30,7 @@ const forms = [
     id: 2021,
     description: "Quarters for 2021",
     title: 2021,
-    content: [<></>],
+    content: [<div key="unique"></div>],
     headingLevel: "h1", // unsure
     expanded: false,
   },
@@ -57,6 +62,7 @@ describe("Tests for HomeAdmin.js", () => {
   });
 
   it("should display an appropriate message for a state with no forms", async () => {
+    listFormsForState.mockResolvedValueOnce([]);
     renderComponent();
 
     const stateDropdown = screen.getByRole("combobox", { name: /State/ });

--- a/services/ui-src/src/components/HomeState/HomeState.jsx
+++ b/services/ui-src/src/components/HomeState/HomeState.jsx
@@ -27,6 +27,7 @@ const HomeState = () => {
     (async () => {
       if (!user.state) {
         navigate("/register-state");
+        return;
       }
 
       const forms = await loadForms(user.state);

--- a/services/ui-src/src/components/HomeState/HomeState.test.jsx
+++ b/services/ui-src/src/components/HomeState/HomeState.test.jsx
@@ -60,9 +60,17 @@ describe("Test HomeState.js", () => {
   it("should still render if listFormsForState fails", async () => {
     listFormsForState.mockRejectedValueOnce(new Error("Mock server error"));
 
+    // Swallow this error (but only this error)
+    const spy = vi.spyOn(console, "log").mockImplementation((arg) => {
+      if (!(arg instanceof Error) || arg.message !== "Mock server error") {
+        throw new Error(arg);
+      }
+    });
+
     renderComponent("CO");
     await waitFor(() => expect(listFormsForState).toHaveBeenCalled());
 
+    spy.mockRestore();
     expect(screen.getByText(/Welcome to SEDS/)).toBeVisible();
   });
 });

--- a/services/ui-src/src/components/Login/Login.jsx
+++ b/services/ui-src/src/components/Login/Login.jsx
@@ -86,6 +86,7 @@ export default function Login() {
           autoFocus
           label="Email"
           name="email"
+          autoComplete="username"
           value={fields.email}
           onChange={onFieldChange}
         ></TextField>
@@ -93,6 +94,7 @@ export default function Login() {
           type="password"
           name="password"
           label="Password"
+          autoComplete="current-password"
           value={fields.password}
           onChange={onFieldChange}
         ></TextField>

--- a/services/ui-src/src/index.jsx
+++ b/services/ui-src/src/index.jsx
@@ -6,32 +6,43 @@ import { BrowserRouter } from "react-router";
 import { Amplify } from "aws-amplify";
 import config from "./config/config";
 
-Amplify.configure({
-  Auth: {
-    Cognito: {
-      userPoolId: config.cognito.USER_POOL_ID,
-      identityPoolId: config.cognito.IDENTITY_POOL_ID,
-      userPoolClientId: config.cognito.APP_CLIENT_ID,
-      loginWith: {
-        oauth: {
-          domain: config.cognito.APP_CLIENT_DOMAIN,
-          redirectSignIn: [config.cognito.REDIRECT_SIGNIN],
-          redirectSignOut: [config.cognito.REDIRECT_SIGNOUT],
-          scopes: ["email", "openid", "profile"],
-          responseType: "token",
+Amplify.configure(
+  {
+    Auth: {
+      Cognito: {
+        userPoolId: config.cognito.USER_POOL_ID,
+        identityPoolId: config.cognito.IDENTITY_POOL_ID,
+        userPoolClientId: config.cognito.APP_CLIENT_ID,
+        loginWith: {
+          oauth: {
+            domain: config.cognito.APP_CLIENT_DOMAIN,
+            redirectSignIn: [config.cognito.REDIRECT_SIGNIN],
+            redirectSignOut: [config.cognito.REDIRECT_SIGNOUT],
+            scopes: ["email", "openid", "profile"],
+            responseType: "token",
+          },
+        },
+      },
+    },
+    API: {
+      REST: {
+        "mdct-seds": {
+          endpoint: config.apiGateway.URL,
+          region: config.apiGateway.REGION,
         },
       },
     },
   },
-  API: {
-    REST: {
-      "mdct-seds": {
-        endpoint: config.apiGateway.URL,
-        region: config.apiGateway.REGION,
+  {
+    API: {
+      REST: {
+        // We can re-enable retries for specific endpoints if/when appropriate.
+        // See: https://docs.amplify.aws/react/frontend/rest-api/fetch-data/
+        retryStrategy: { strategy: "no-retry" },
       },
     },
-  },
-});
+  }
+);
 
 const root = createRoot(document.getElementById("root"));
 root.render(

--- a/services/ui-src/src/store/store.test.js
+++ b/services/ui-src/src/store/store.test.js
@@ -50,12 +50,20 @@ describe("useStore actions", () => {
     });
 
     it("should flag a load error if an API call fails", async () => {
-      getForm.mockRejectedValueOnce("Mock Server Error");
+      getForm.mockRejectedValueOnce(new Error("Mock server error"));
+
+      // Swallow this error (but only this error)
+      const spy = vi.spyOn(console, "error").mockImplementation((arg) => {
+        if (!(arg instanceof Error) || arg.message !== "Mock server error") {
+          throw new Error(arg);
+        }
+      });
 
       const { loadForm } = useStore.getState();
       await loadForm("CO", 2025, 4, "21E");
       const state = useStore.getState();
 
+      spy.mockRestore();
       expect(state.loadError).toBe(true);
     });
 


### PR DESCRIPTION
### Description
This PR is a collection of little housekeeping tasks. Various things which caused noise in the console are quieter now.

I focused on the browser console when browsing the site, and the terminal when running the tests in ui-src. This PR does not address console output from `yarn install`, the unit tests in app-api, the Cloudwatch logs, or `./run local`.

The only actual bug was in the form header: we would not save the form immediately after updating FPL, because the `.then()` call was being made on an undefined value.

### Related ticket(s)
CMDCT-4370

---
### How to test
https://d3f40fg4xeptib.cloudfront.net/

1. Execute the unit tests with `yarn test --run`. Look how quiet it is! Ooh, ahh.
2. Log in to the site, open the browser console, and click around. Wow, so few errors!
   - Not _no_ errors, but fewer :)

---
### Pre-review checklist
- ~[ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary~
- ~[ ] I have updated relevant documentation, if necessary~
- ~[ ] I have performed a self-review of my code~
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist

#### Review
- ~[ ] Design: This work has been reviewed and approved by design, if necessary~
- ~[ ] Product: This work has been reviewed and approved by product owner, if necessary~

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- ~[ ] These changes are significant enough to require an update to the SIA.~
- ~[ ] These changes are significant enough to require a penetration test.~
